### PR TITLE
Support percentile_cont.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: nextest run
+          command: test

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1059,13 +1059,27 @@ impl fmt::Display for Expr {
             }
             Expr::PercentileCont {
                 percentile,
-                null_treatment: _,
-                value_expr: _,
+                null_treatment,
+                value_expr,
                 within_group,
                 window_spec,
                 alias,
             } => {
-                write!(f, "PERCENTILE_CONT({percentile})")?;
+                //write!(f, "PERCENTILE_CONT({percentile})")?;
+                write!(f, "PERCENTILE_CONT(")?;
+
+                if let Some(expr) = value_expr {
+                    write!(f, "{expr}, ")?;
+                }
+
+                write!(f, "{percentile}")?;
+
+                if let Some(null_treat) = null_treatment {
+                    write!(f, "{null_treat}")?;
+                }
+
+                write!(f, ")")?;
+
                 if let Some(group) = within_group {
                     write!(f, " WITHIN GROUP (ORDER BY {})", group)?;
                 };
@@ -3804,6 +3818,15 @@ pub struct Function {
 pub enum NullTreatment {
     IGNORE,
     RESPECT,
+}
+
+impl fmt::Display for NullTreatment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            NullTreatment::IGNORE => " IGNORE NULLS",
+            NullTreatment::RESPECT => " RESPECT NULLS",
+        })
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -612,6 +612,8 @@ pub enum Expr {
     /// ```
     PercentileCont {
         percentile: Value,
+        null_treatment: Option<NullTreatment>,
+        value_expr: Option<Box<Expr>>,
         within_group: Option<Box<OrderByExpr>>,
         window_spec: Option<WindowSpec>,
         alias: Option<WithSpan<Ident>>,
@@ -1057,6 +1059,8 @@ impl fmt::Display for Expr {
             }
             Expr::PercentileCont {
                 percentile,
+                null_treatment: _,
+                value_expr: _,
                 within_group,
                 window_spec,
                 alias,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -529,7 +529,7 @@ fn parse_percentile_cont() {
     let statements = vec![
         r#"SELECT PERCENTILE_CONT(metric, 0.5 RESPECT NULLS) OVER (PARTITION BY team) AS median FROM metric_sample"#,
         r#"SELECT PERCENTILE_CONT(metric, 0.5 IGNORE NULLS) OVER ()"#,
-        r#"SELECT PERCENTILE_CONT(metric, 0.5) OVER()"#,
+        r#"SELECT PERCENTILE_CONT(metric, 0.5) OVER ()"#,
     ];
 
     for statement in statements {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -523,3 +523,16 @@ fn parse_map_access_offset() {
         bigquery().verified_only_select(sql);
     }
 }
+
+#[test]
+fn parse_percentile_cont() {
+    let statements = vec![
+        r#"SELECT PERCENTILE_CONT(metric, 0.5 RESPECT NULLS) OVER (PARTITION BY team) AS median FROM metric_sample"#,
+        r#"SELECT PERCENTILE_CONT(metric, 0.5 IGNORE NULLS) OVER ()"#,
+        r#"SELECT PERCENTILE_CONT(metric, 0.5) OVER()"#,
+    ];
+
+    for statement in statements {
+        assert_eq!(bigquery().verified_stmt(statement).to_string(), statement);
+    }
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7789,4 +7789,28 @@ fn parse_percentile_cont() {
             "Expected ), found: ,\nNear `WITHIN GROUP (ORDER BY metric`".to_owned()
         )
     );
+
+    // BiqQuery syntax not supported
+    // Dialects has different error for expecting number:
+    //  Expected a concrete value VS Expected literal number
+    // So pick only some
+    let same_number_err_dialects = TestedDialects {
+        dialects: vec![
+            Box::new(RedshiftSqlDialect {}),
+            Box::new(MySqlDialect {}),
+            Box::new(SQLiteDialect {}),
+            Box::new(DuckDbDialect {}),
+        ],
+        options: None,
+    };
+    let bigquery_sql = r#"SELECT PERCENTILE_CONT(metric, 0.5) OVER ()"#;
+    assert_eq!(
+        same_number_err_dialects
+            .parse_sql_statements(bigquery_sql)
+            .unwrap_err(),
+        ParserError::ParserError(
+            "Expected a concrete value, found: metric\nNear `SELECT PERCENTILE_CONT(metric`"
+                .to_owned()
+        )
+    );
 }


### PR DESCRIPTION
### Syntax definition
https://learn.microsoft.com/en-us/sql/t-sql/functions/percentile-cont-transact-sql?view=sql-server-ver16#syntax

BigQuery has different: https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#percentile_cont