### PR TITLE
Single line hash comments support on BigQuery.

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1059,7 +1059,7 @@ impl<'a> Tokenizer<'a> {
                 '^' => self.consume_and_return(chars, Token::Caret),
                 '{' => self.consume_and_return(chars, Token::LBrace),
                 '}' => self.consume_and_return(chars, Token::RBrace),
-                '#' if dialect_of!(self is SnowflakeDialect) => {
+                '#' if dialect_of!(self is BigQueryDialect | SnowflakeDialect) => {
                     chars.next(); // consume the '#', starting a snowflake single-line comment
                     let comment = self.tokenize_single_line_comment(chars);
                     Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {


### PR DESCRIPTION
# Why
Single line **hash comment** on BQ are raising a parsing error like `['SQL parser failed: Expected end of statement, found: #']`
for snippets like
```
...
    USING (account_id)

# ROW_NUMBER() is just so we can filter on action type :D
QUALIFY action_type IS NOT NULL
```

This PR is solving it.