### PR TITLE
bigquery: allow string escaping

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1365,7 +1365,7 @@ impl<'a> Tokenizer<'a> {
                     // consume
                     chars.next();
                     // slash escaping is specific to MySQL dialect.
-                    if dialect_of!(self is MySqlDialect) {
+                    if dialect_of!(self is MySqlDialect | BigQueryDialect) {
                         if let Some(next) = chars.peek() {
                             if !self.unescape {
                                 // In no-escape mode, the given query has to be saved completely including backslashes.

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1335,7 +1335,7 @@ impl<'a> Tokenizer<'a> {
         self.tokenizer_error(starting_loc, "Unterminated encoded string literal")
     }
 
-    /// Read a single quoted string, starting with the opening quote.
+    /// Read a quoted string, starting with the opening quote.
     fn tokenize_quoted_string(
         &self,
         chars: &mut State,
@@ -1364,7 +1364,7 @@ impl<'a> Tokenizer<'a> {
                 '\\' => {
                     // consume
                     chars.next();
-                    // slash escaping is specific to MySQL dialect.
+                    // slash escaping is specific to MySQL / BigQuery dialect.
                     if dialect_of!(self is MySqlDialect | BigQueryDialect) {
                         if let Some(next) = chars.peek() {
                             if !self.unescape {
@@ -1376,12 +1376,12 @@ impl<'a> Tokenizer<'a> {
                                 // See https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences
                                 let n = match next {
                                     '\'' | '\"' | '\\' | '%' | '_' => *next,
-                                    '0' => '\0',
+                                    '0' if dialect_of!(self is MySqlDialect) => '\0',
                                     'b' => '\u{8}',
                                     'n' => '\n',
                                     'r' => '\r',
                                     't' => '\t',
-                                    'Z' => '\u{1a}',
+                                    'Z' if dialect_of!(self is MySqlDialect) => '\u{1a}',
                                     _ => *next,
                                 };
                                 s.push(n);

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 
 use sqlparser::ast::*;
 use sqlparser::dialect::{BigQueryDialect, GenericDialect};
-use sqlparser::parser::ParserError;
+use sqlparser::parser::{ParserError, ParserOptions};
 use sqlparser::tokenizer::*;
 use test_utils::*;
 
@@ -1239,4 +1239,19 @@ fn test_bigquery_single_line_comment_parsing() {
         "SELECT book# this is a comment \n FROM library",
         "SELECT book FROM library",
     );
+}
+
+#[test]
+fn test_regexp_string_double_quote() {
+    let dialect = TestedDialects {
+        dialects: vec![Box::new(BigQueryDialect {})],
+        options: Some(ParserOptions::new().with_unescape(false)),
+    };
+
+    dialect.verified_stmt(r"SELECT 'I\'m fine'");
+    dialect.verified_stmt(r"SELECT 'I\\\'m fine'");
+    dialect.verified_stmt(r#"SELECT 'I''m fine'"#);
+    dialect.verified_stmt(r#"SELECT "I'm ''fine''""#);
+    dialect.verified_stmt(r#"SELECT "I\\\"m fine""#);
+    dialect.verified_stmt(r#"SELECT "[\"\\[\\]]""#);
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -845,10 +845,10 @@ fn parse_like() {
 
         // Test with escape char
         let sql = &format!(
-            "SELECT * FROM customers WHERE name {}LIKE '%a' ESCAPE '\\'",
+            r#"SELECT * FROM customers WHERE name {}LIKE '%a' ESCAPE '\\'"#,
             if negated { "NOT " } else { "" }
         );
-        let select = bigquery_unescaped().verified_only_select(sql);
+        let select = bigquery().verified_only_select_with_canonical(sql, "");
         assert_eq!(
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
@@ -903,10 +903,10 @@ fn parse_similar_to() {
 
         // Test with escape char
         let sql = &format!(
-            "SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\'",
+            r#"SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\'"#,
             if negated { "NOT " } else { "" }
         );
-        let select = bigquery().verified_only_select(sql);
+        let select = bigquery().verified_only_select_with_canonical(sql, "");
         assert_eq!(
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),
@@ -920,10 +920,10 @@ fn parse_similar_to() {
 
         // This statement tests that SIMILAR TO and NOT SIMILAR TO have the same precedence.
         let sql = &format!(
-            "SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\' IS NULL",
+            r#"SELECT * FROM customers WHERE name {}SIMILAR TO '%a' ESCAPE '\\' IS NULL"#,
             if negated { "NOT " } else { "" }
         );
-        let select = bigquery().verified_only_select(sql);
+        let select = bigquery().verified_only_select_with_canonical(sql, "");
         assert_eq!(
             Expr::IsNull(Box::new(Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name").empty_span())),


### PR DESCRIPTION
# Why
We want to have string escaping logic also in BigQuery dialect with backslashes (https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#escape_sequences)