### PR TITLE
Redshift escape string literal logic.

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -38,7 +38,8 @@ use sqlparser_derive::{Visit, VisitMut};
 
 use crate::ast::DollarQuotedString;
 use crate::dialect::{
-    BigQueryDialect, DuckDbDialect, GenericDialect, HiveDialect, SnowflakeDialect,
+    BigQueryDialect, DuckDbDialect, GenericDialect, HiveDialect, RedshiftSqlDialect,
+    SnowflakeDialect,
 };
 use crate::dialect::{Dialect, MySqlDialect};
 use crate::keywords::{Keyword, ALL_KEYWORDS, ALL_KEYWORDS_INDEX};
@@ -1365,7 +1366,7 @@ impl<'a> Tokenizer<'a> {
                     // consume
                     chars.next();
                     // slash escaping is specific to MySQL / BigQuery dialect.
-                    if dialect_of!(self is MySqlDialect | BigQueryDialect) {
+                    if dialect_of!(self is MySqlDialect | BigQueryDialect | RedshiftSqlDialect) {
                         if let Some(next) = chars.peek() {
                             if !self.unescape {
                                 // In no-escape mode, the given query has to be saved completely including backslashes.


### PR DESCRIPTION
# Why
We want to be able accept in regexp escaped string literals.