### PR TITLE
BiqQuery correct struct definition parsing.

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1824,18 +1824,14 @@ impl<'a> Parser<'a> {
     fn parse_big_query_struct_field_def(
         &mut self,
     ) -> Result<(StructField, MatchedTrailingBracket), ParserError> {
-        let is_anonymous_field = if let Token::Word(w) = self.peek_token().token {
-            ALL_KEYWORDS
-                .binary_search(&w.value.to_uppercase().as_str())
-                .is_ok()
+        let field_name: Option<WithSpan<Ident>> = if let Token::Word(_) = self.peek_token().token {
+            match self.peek_nth_token(1).token {
+                // if there is another word it is named field
+                Token::Word(_) => Some(self.parse_identifier()?),
+                _ => None,
+            }
         } else {
-            false
-        };
-
-        let field_name = if is_anonymous_field {
             None
-        } else {
-            Some(self.parse_identifier()?)
         };
 
         let (field_type, trailing_bracket) = self.parse_data_type_helper()?;

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -255,7 +255,7 @@ fn parse_typed_struct_syntax() {
     // typed struct syntax https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#typed_struct_syntax
     // syntax: STRUCT<[field_name] field_type, ...>( expr1 [, ... ])
 
-    let sql = r#"SELECT STRUCT<INT64>(5), STRUCT<x INT64, y STRING>(1, t.str_col), STRUCT<arr ARRAY<FLOAT64>, str STRUCT<BOOL>>(nested_col)"#;
+    let sql = r#"SELECT STRUCT<INT64>(5), STRUCT<x INT64, y STRING, timezone STRING>(1, t.str_col, timezone), STRUCT<arr ARRAY<FLOAT64>, str STRUCT<BOOL>>(nested_col)"#;
     let select = bigquery().verified_only_select(sql);
     assert_eq!(3, select.projection.len());
     assert_eq!(
@@ -285,6 +285,7 @@ fn parse_typed_struct_syntax() {
                     ]
                     .empty_span()
                 ),
+                Expr::Identifier(Ident::new("timezone").empty_span()),
             ],
             fields: vec![
                 StructField {
@@ -293,6 +294,10 @@ fn parse_typed_struct_syntax() {
                 },
                 StructField {
                     field_name: Some(Ident::new("y").empty_span()),
+                    field_type: DataType::String(None),
+                },
+                StructField {
+                    field_name: Some(Ident::new("timezone").empty_span()),
                     field_type: DataType::String(None),
                 },
             ],


### PR DESCRIPTION
# Why
In biqquery struct definition like `STRUCT<timezone STRING>(..)` should be valid expression and not raising parsing error.