### PR TITLE
BigQuery partition by in create table.

### DIFF
--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -72,6 +72,7 @@ pub struct CreateTableBuilder {
     pub default_charset: Option<String>,
     pub collation: Option<String>,
     pub on_commit: Option<OnCommit>,
+    pub partitioned_by: Option<Expr>,
     pub on_cluster: Option<String>,
     pub primary_key: Option<Vec<WithSpan<Ident>>>,
     pub order_by: Option<Vec<WithSpan<Ident>>>,
@@ -112,6 +113,7 @@ impl CreateTableBuilder {
             on_cluster: None,
             primary_key: None,
             order_by: None,
+            partitioned_by: None,
             cluster_by: None,
             strict: false,
             table_ttl: None,
@@ -236,6 +238,11 @@ impl CreateTableBuilder {
         self
     }
 
+    pub fn partitioned_by(mut self, partitioned_by: Option<Expr>) -> Self {
+        self.partitioned_by = partitioned_by;
+        self
+    }
+
     pub fn on_cluster(mut self, on_cluster: Option<String>) -> Self {
         self.on_cluster = on_cluster;
         self
@@ -301,6 +308,7 @@ impl CreateTableBuilder {
             on_cluster: self.on_cluster,
             primary_key: self.primary_key,
             order_by: self.order_by,
+            partitioned_by: self.partitioned_by,
             cluster_by: self.cluster_by,
             strict: self.strict,
             table_ttl: self.table_ttl,
@@ -342,6 +350,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 default_charset,
                 collation,
                 on_commit,
+                partitioned_by,
                 on_cluster,
                 primary_key,
                 order_by,
@@ -375,6 +384,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 default_charset,
                 collation,
                 on_commit,
+                partitioned_by,
                 on_cluster,
                 primary_key,
                 order_by,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1604,6 +1604,7 @@ pub enum Statement {
         default_charset: Option<String>,
         collation: Option<String>,
         on_commit: Option<OnCommit>,
+        partitioned_by: Option<Expr>,
         /// ClickHouse "ON CLUSTER" clause:
         /// <https://clickhouse.com/docs/en/sql-reference/distributed-ddl/>
         on_cluster: Option<String>,
@@ -2620,6 +2621,7 @@ impl fmt::Display for Statement {
                 auto_increment_offset,
                 collation,
                 on_commit,
+                partitioned_by,
                 on_cluster,
                 primary_key,
                 order_by,
@@ -2784,6 +2786,9 @@ impl fmt::Display for Statement {
                 }
                 if let Some(order_by) = order_by {
                     write!(f, " ORDER BY ({})", display_comma_separated(order_by))?;
+                }
+                if let Some(expr) = partitioned_by {
+                    write!(f, " PARTITION BY {expr}")?;
                 }
                 if let Some(cluster_by) = cluster_by {
                     write!(f, " CLUSTER BY ({})", display_comma_separated(cluster_by))?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -197,7 +197,7 @@ impl fmt::Display for ParserError {
 impl std::error::Error for ParserError {}
 
 // By default, allow expressions up to this deep before erroring
-const DEFAULT_REMAINING_DEPTH: usize = 41;
+const DEFAULT_REMAINING_DEPTH: usize = 38;
 
 /// Composite types declarations using angle brackets syntax can be arbitrary
 /// nested such that the following declaration is possible:

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,7 +33,7 @@ use IsOptional::*;
 use crate::ast::helpers::stmt_create_table::CreateTableBuilder;
 use crate::ast::*;
 use crate::dialect::*;
-use crate::keywords::{self, Keyword, ALL_KEYWORDS};
+use crate::keywords::{self, Keyword};
 use crate::tokenizer::*;
 
 mod alter;
@@ -4083,6 +4083,13 @@ impl<'a> Parser<'a> {
             None
         };
 
+        // In BigQuery PARITION BY can be also defined after columns
+        let partitioned_by = if self.parse_keywords(&[Keyword::PARTITION, Keyword::BY]) {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+
         // In Snowflake CLUSTER BY can be also defined after columns
         if self.parse_keywords(&[Keyword::CLUSTER, Keyword::BY]) {
             self.expect_token(&Token::LParen)?;
@@ -4181,6 +4188,7 @@ impl<'a> Parser<'a> {
             .default_charset(default_charset)
             .collation(collation)
             .on_commit(on_commit)
+            .partitioned_by(partitioned_by)
             .on_cluster(on_cluster)
             .strict(strict)
             .table_ttl(table_ttl)

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1262,3 +1262,10 @@ fn test_regexp_string_double_quote() {
     bigquery_unescaped().verified_stmt(r#"SELECT "I\\\"m fine""#);
     bigquery_unescaped().verified_stmt(r#"SELECT "[\"\\[\\]]""#);
 }
+
+#[test]
+fn test_create_table_with_partition_by() {
+    bigquery().verified_stmt(
+        "CREATE TABLE mytable (id INT64, timestamp TIMESTAMP) PARTITION BY DATE(timestamp)",
+    );
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7719,8 +7719,14 @@ fn parse_uncache_table() {
 #[test]
 fn parse_deeply_nested_parens_hits_recursion_limits() {
     let sql = "(".repeat(1000);
-    let res = parse_sql_statements(&sql);
-    assert_eq!(ParserError::RecursionLimitExceeded, res.unwrap_err());
+    let dialect = GenericDialect {};
+    let res = Parser::new(&dialect)
+        .try_with_sql(&sql)
+        .expect("tokenize to work")
+        .with_recursion_limit(38)
+        .parse_statements();
+
+    assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7719,14 +7719,8 @@ fn parse_uncache_table() {
 #[test]
 fn parse_deeply_nested_parens_hits_recursion_limits() {
     let sql = "(".repeat(1000);
-    let dialect = GenericDialect {};
-    let res = Parser::new(&dialect)
-        .try_with_sql(&sql)
-        .expect("tokenize to work")
-        .with_recursion_limit(38)
-        .parse_statements();
-
-    assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
+    let res = parse_sql_statements(&sql);
+    assert_eq!(ParserError::RecursionLimitExceeded, res.unwrap_err());
 }
 
 #[test]


### PR DESCRIPTION
# Why
BigQuery create table statement is supporting `PARTITION BY <expr>` after column difinition. This PR is allowing us to parse these statements.

[BigQuery doc](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement)