### PR TITLE
Zdenko/syn 3025 parse error create external table options

### DIFF
--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -58,6 +58,7 @@ pub struct CreateTableBuilder {
     pub constraints: Vec<TableConstraint>,
     pub hive_distribution: HiveDistributionStyle,
     pub hive_formats: Option<HiveFormat>,
+    pub table_options: Vec<SqlOption>,
     pub table_properties: Vec<SqlOption>,
     pub with_options: Vec<SqlOption>,
     pub file_format: Option<FileFormat>,
@@ -96,6 +97,7 @@ impl CreateTableBuilder {
             constraints: vec![],
             hive_distribution: HiveDistributionStyle::NONE,
             hive_formats: None,
+            table_options: vec![],
             table_properties: vec![],
             with_options: vec![],
             file_format: None,
@@ -167,6 +169,11 @@ impl CreateTableBuilder {
 
     pub fn hive_formats(mut self, hive_formats: Option<HiveFormat>) -> Self {
         self.hive_formats = hive_formats;
+        self
+    }
+
+    pub fn table_options(mut self, table_options: Vec<SqlOption>) -> Self {
+        self.table_options = table_options;
         self
     }
 
@@ -291,6 +298,7 @@ impl CreateTableBuilder {
             constraints: self.constraints,
             hive_distribution: self.hive_distribution,
             hive_formats: self.hive_formats,
+            table_options: self.table_options,
             table_properties: self.table_properties,
             with_options: self.with_options,
             file_format: self.file_format,
@@ -336,6 +344,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 constraints,
                 hive_distribution,
                 hive_formats,
+                table_options,
                 table_properties,
                 with_options,
                 file_format,
@@ -370,6 +379,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 constraints,
                 hive_distribution,
                 hive_formats,
+                table_options,
                 table_properties,
                 with_options,
                 file_format,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1591,6 +1591,7 @@ pub enum Statement {
         hive_distribution: HiveDistributionStyle,
         hive_formats: Option<HiveFormat>,
         table_properties: Vec<SqlOption>,
+        table_options: Vec<SqlOption>,
         with_options: Vec<SqlOption>,
         file_format: Option<FileFormat>,
         location: Option<String>,
@@ -2599,6 +2600,7 @@ impl fmt::Display for Statement {
                 name,
                 columns,
                 constraints,
+                table_options,
                 table_properties,
                 with_options,
                 or_replace,
@@ -2754,7 +2756,8 @@ impl fmt::Display for Statement {
                         }
                     }
                 }
-                if *external {
+                // BigQuey doesn't have this external format
+                if *external && file_format.is_some() && location.is_some() {
                     write!(
                         f,
                         " STORED AS {} LOCATION '{}'",
@@ -2792,6 +2795,9 @@ impl fmt::Display for Statement {
                 }
                 if let Some(cluster_by) = cluster_by {
                     write!(f, " CLUSTER BY ({})", display_comma_separated(cluster_by))?;
+                }
+                if !table_options.is_empty() {
+                    write!(f, " OPTIONS ({})", display_comma_separated(table_options))?;
                 }
                 if let Some(table_ttl) = table_ttl {
                     write!(f, " TTL {table_ttl}")?;

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -78,6 +78,7 @@ pub enum Value {
     /// OBJECT constant as used by Snowflake
     /// https://docs.snowflake.com/en/sql-reference/data-types-semistructured#object-constants
     ObjectConstant(Vec<ObjectConstantKeyValue>),
+    Array(Vec<Value>),
 }
 
 impl fmt::Display for Value {
@@ -113,6 +114,10 @@ impl fmt::Display for Value {
                     }
                     write!(f, "{}", " }")
                 }
+            }
+            Value::Array(values) => {
+                let collected: Vec<String> = values.iter().map(|v| format!("{}", v)).collect();
+                write!(f, "[{}]", collected.join(", "))
             }
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -197,7 +197,7 @@ impl fmt::Display for ParserError {
 impl std::error::Error for ParserError {}
 
 // By default, allow expressions up to this deep before erroring
-const DEFAULT_REMAINING_DEPTH: usize = 38;
+const DEFAULT_REMAINING_DEPTH: usize = 37;
 
 /// Composite types declarations using angle brackets syntax can be arbitrary
 /// nested such that the following declaration is possible:

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3178,11 +3178,13 @@ impl<'a> Parser<'a> {
         };
         let location = hive_formats.location.clone();
         let table_properties = self.parse_options(Keyword::TBLPROPERTIES)?;
+        let table_options = self.parse_options(Keyword::OPTIONS)?;
         Ok(CreateTableBuilder::new(table_name)
             .columns(columns)
             .constraints(constraints)
             .hive_distribution(hive_distribution)
             .hive_formats(Some(hive_formats))
+            .table_options(table_options)
             .table_properties(table_properties)
             .or_replace(or_replace)
             .if_not_exists(if_not_exists)
@@ -5198,6 +5200,21 @@ impl<'a> Parser<'a> {
                 }
                 self.expect_token(&Token::RBrace)?;
                 Ok(Value::ObjectConstant(fields))
+            }
+            Token::LBracket => {
+                if self.consume_token(&Token::RBracket) {
+                    return Ok(Value::ObjectConstant(vec![]));
+                }
+                let mut fields = vec![];
+                loop {
+                    let value = self.parse_value()?;
+                    fields.push(value);
+                    if !self.consume_token(&Token::Comma) {
+                        break;
+                    }
+                }
+                self.expect_token(&Token::RBracket)?;
+                Ok(Value::Array(fields))
             }
             unexpected => self.expected(
                 "a value",

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1269,3 +1269,10 @@ fn test_create_table_with_partition_by() {
         "CREATE TABLE mytable (id INT64, timestamp TIMESTAMP) PARTITION BY DATE(timestamp)",
     );
 }
+
+#[test]
+fn test_create_external_table_with_options() {
+    bigquery().verified_stmt(
+        r#"CREATE EXTERNAL TABLE mytable (id INT64, timestamp TIMESTAMP) OPTIONS (sheet_range = "synq", skip_leading_rows = 1, format = "GOOGLE_SHEETS", uris = ["https://docs.google.com/spreadsheets/d/1g3xwWi1r-Ln2VVwv4mswwmqyfMeoJglv-MS80ywASGI/edit#gid=0"])"#,
+    );
+}


### PR DESCRIPTION
# Why
We want to support `CREATE EXTERNAL TABLE (..) OPTIONS(...)` syntax (BigQuery example)