### PR TITLE
Fix BigQuery options

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4145,6 +4145,8 @@ impl<'a> Parser<'a> {
             None
         };
 
+        let table_options = self.parse_options(Keyword::OPTIONS)?;
+
         // Parse optional `AS ( query )`
         let query = if self.parse_keyword(Keyword::AS) {
             Some(Box::new(self.parse_query()?))
@@ -4192,8 +4194,7 @@ impl<'a> Parser<'a> {
             };
 
         let strict = self.parse_keyword(Keyword::STRICT);
-
-        let table_options = self.parse_options(Keyword::OPTIONS)?;
+        
         //Databricks has TBLPROPERTIES after COMMENT
         let _table_properties = self.parse_options(Keyword::TBLPROPERTIES)?;
         table_properties.extend(_table_properties);

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1385,3 +1385,10 @@ fn test_options_expression() {
         "CREATE TABLE `myproject`.`mydataset`.`mytable` (id INT64) OPTIONS (max_staleness = INTERVAL '0-0 0 0:15:0' YEAR TO SECOND)",
     );
 }
+
+#[test]
+fn test_create_table_options_expression() {
+    bigquery().verified_stmt(
+        "CREATE OR REPLACE TABLE `myproject`.`mydataset`.`mytable` OPTIONS (description = \"\"\"Project entity stream base\"\"\") AS (SELECT * FROM `myproject`.`mydataset`.`othertable`)",
+    );
+}


### PR DESCRIPTION
Support for:

```
CREATE OR REPLACE TABLE `myproject`.`mydataset`.`mytable` OPTIONS (description = \"\"\"...\"\"\") AS (SELECT * FROM `myproject`.`mydataset`.`othertable`)
```

