### PR TITLE
Support INTERVAL as argument.

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -830,8 +830,7 @@ impl<'a> Parser<'a> {
                 Keyword::TRIM => self.parse_trim_expr(),
                 Keyword::INTERVAL
                     if self.peek_token().token != Token::Period
-                        && self.peek_token().token != Token::Comma
-                        && self.maybe_parse(|parser| parser.parse_interval()).is_some() =>
+                        && self.peek_token().token != Token::Comma =>
                 {
                     self.parse_interval()
                 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4181,6 +4181,7 @@ fn parse_interval() {
     verified_only_select("SELECT INTERVAL '1' MINUTE TO SECOND");
     verified_only_select("SELECT INTERVAL '1 YEAR'");
     verified_only_select("SELECT INTERVAL '1 YEAR' AS one_year");
+    verified_only_select("SELECT date_sub(now(), INTERVAL 10 DAY)");
     one_statement_parses_to(
         "SELECT INTERVAL '1 YEAR' one_year",
         "SELECT INTERVAL '1 YEAR' AS one_year",


### PR DESCRIPTION
# Why
We want to support common sql syntax `DATE_SUB(date, INTERVAL value interval)` (doc eg. https://www.w3schools.com/sql/func_mysql_date_sub.asp).

The issue was parsing INTERVAL logic. We were introducing support `interval` table name or aliases here: https://github.com/getsynq/sqlparser-rs/commit/093d9742236ca87b1f366ae33a0892ff2a1233a5.

The conditions are ok except the last
```
&& self.maybe_parse(|parser| parser.parse_interval()).is_some() => {self.parse_interval()}
```
the `parse_interval` inside `maybe_parse` is already consuming tokens, so next call of `parse_interval()` is returning parser error.

This PR is keeping green the origin tests targeted to `interval table aliases` logic.