### PR TITLE
fix(parser): support parenthesized SELECT in INSERT statements

### DIFF
--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1454,3 +1454,20 @@ fn test_describe_table() {
 fn test_asof_join() {
     snowflake().verified_stmt("SELECT * FROM table1 ASOF JOIN table2 MATCH_CONDITION (table1.timestamp <= table2.timestamp) ON table1.id = table2.id");
 }
+
+#[test]
+fn test_insert_with_parenthesized_select() {
+    // Test INSERT INTO with parenthesized SELECT subquery
+    // This syntax is valid in many SQL dialects including Snowflake
+    snowflake_and_generic().verified_stmt("INSERT INTO t (a, b) (SELECT x, y FROM s)");
+
+    // With table alias
+    snowflake_and_generic().verified_stmt("INSERT INTO t (a, b) (SELECT s.x, s.y FROM s AS s)");
+
+    // Without column list
+    snowflake_and_generic().verified_stmt("INSERT INTO t (SELECT x, y FROM s)");
+
+    // With unquoted table alias (PR-6612 reproducer)
+    snowflake_and_generic()
+        .verified_stmt(r#"INSERT INTO "db"."schema"."t" ("a", "b") (SELECT "s"."a", "s"."b" FROM "db"."schema"."s" AS s)"#);
+}


### PR DESCRIPTION
## Summary
- Fix parsing of INSERT statements with parenthesized SELECT subqueries
- Add lookahead check to distinguish column lists from subqueries
- Restrict Hive-specific `after_columns` parsing to Hive dialect only

Fixes [PR-6612](https://linear.app/synq/issue/PR-6612)

## Test plan
- [x] Added tests for `INSERT INTO t (a, b) (SELECT ...)` syntax
- [x] Added tests for `INSERT INTO t (SELECT ...)` without column list
- [x] Verified all 750 existing tests pass
- [x] Verified Hive INSERT tests still work