### PR TITLE
feat(corpus): improve test reporting and add regression tracking

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -57,67 +57,23 @@ jobs:
           workflow: corpus.yml
           search_artifacts: true
 
+      - name: Generate comparison report
+        if: github.event_name == 'pull_request_target'
+        id: generate_report
+        run: |
+          BASELINE_ARG=""
+          if [ -f target/baseline/corpus-report.json ]; then
+            BASELINE_ARG="target/baseline/corpus-report.json"
+          fi
+          node scripts/compare-corpus-reports.js target/corpus-report.json $BASELINE_ARG > target/report.md
+
       - name: Post PR comment
         if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const current = JSON.parse(fs.readFileSync('target/corpus-report.json', 'utf8'));
-
-            let body = '## Corpus Parsing Report\n\n';
-            const totalTests = current.total_passed + current.total_failed;
-            const passRate = (current.total_passed / totalTests * 100).toFixed(1);
-            body += `**Total: ${current.total_passed} passed, ${current.total_failed} failed** (${passRate}% pass rate)\n\n`;
-
-            let hasBaseline = false;
-            let baseline = null;
-            try {
-              baseline = JSON.parse(fs.readFileSync('target/baseline/corpus-report.json', 'utf8'));
-              hasBaseline = true;
-            } catch (e) {
-              // no baseline available
-            }
-
-            body += '| Dialect | Passed | Failed | Total | Pass Rate |';
-            if (hasBaseline) body += ' Delta |';
-            body += '\n';
-
-            body += '|---------|-------:|-------:|------:|----------:|';
-            if (hasBaseline) body += '------:|';
-            body += '\n';
-
-            for (const [dialect, stats] of Object.entries(current.dialects)) {
-              const total = stats.passed + stats.failed;
-              const rate = (stats.passed / total * 100).toFixed(1);
-              body += `| ${dialect} | ${stats.passed} | ${stats.failed} | ${total} | ${rate}% |`;
-
-              if (hasBaseline && baseline.dialects[dialect]) {
-                const base = baseline.dialects[dialect];
-                const diff = stats.passed - base.passed;
-                if (diff > 0) body += ` **+${diff}** |`;
-                else if (diff < 0) body += ` **${diff}** |`;
-                else body += ` - |`;
-              } else if (hasBaseline) {
-                body += ` *new* |`;
-              }
-
-              body += '\n';
-            }
-
-            if (hasBaseline) {
-              const totalDiff = current.total_passed - baseline.total_passed;
-              body += '\n';
-              if (totalDiff > 0) {
-                body += `**Improvement: +${totalDiff} more files parsed successfully**\n`;
-              } else if (totalDiff < 0) {
-                body += `**Regression: ${totalDiff} fewer files parsed successfully**\n`;
-              } else {
-                body += '**No change in parsing coverage**\n';
-              }
-            } else {
-              body += '\n*No baseline available for comparison (first run on this branch)*\n';
-            }
+            const body = fs.readFileSync('target/report.md', 'utf8');
 
             // Find existing comment to update
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -38,6 +38,14 @@ jobs:
         continue-on-error: true
         run: cargo test --test sqlparser_corpus
 
+      - name: Create fallback report if tests crashed
+        if: always()
+        run: |
+          if [ ! -f target/corpus-report.json ]; then
+            echo "Warning: corpus-report.json not found (tests may have crashed)"
+            echo '{"summary":{"total_passed":0,"total_failed":0,"total_tests":0},"by_dialect":{},"test_results":{}}' > target/corpus-report.json
+          fi
+
       - name: Upload corpus report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Run corpus tests
         continue-on-error: true
+        env:
+          # Increase stack size to 16MB to prevent stack overflow in deeply nested parser tests
+          RUST_MIN_STACK: 16777216
         run: cargo test --test sqlparser_corpus
 
       - name: Create fallback report if tests crashed

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Cargo.lock
 
 # External corpus (symlinked from kernel-cll-corpus repo)
 /tests/corpus
+target/corpus-results/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Cargo.lock
 # External corpus (symlinked from kernel-cll-corpus repo)
 /tests/corpus
 target/corpus-results/
+target/corpus-current-test.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ Corpus tests in `tests/sqlparser_corpus.rs` parse real SQL from `tests/corpus/{d
 # Run corpus tests with timestamped results and comparison
 ./scripts/run-corpus-tests.sh --compare
 
+# Run manually with increased stack size (if needed)
+RUST_MIN_STACK=16777216 cargo test --test sqlparser_corpus
+
 # Compare two specific reports
 node scripts/compare-corpus-reports.js target/corpus-report.json target/corpus-results/corpus-report-*.json
 
@@ -63,7 +66,13 @@ ls -lht target/corpus-results/corpus-report-*.json
 - Uses custom test harness (`harness = false` in Cargo.toml with libtest_mimic)
 - `customer_*` dialect prefixes are automatically stripped (customer_bigquery → bigquery)
 - Reports track individual test results for regression detection
+- Stack size increased to 16MB (`RUST_MIN_STACK=16777216`) to handle deeply nested queries
 - See `scripts/README.md` for detailed usage
+
+**Debugging stack overflows:**
+- If tests crash despite increased stack, use binary search to find problematic files
+- Run subsets: `cargo test --test sqlparser_corpus -- dialect/category/`
+- Check test logs for patterns before crash
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,15 +49,21 @@ Each test file contains comprehensive parsing tests for dialect-specific syntax.
 ### Corpus Testing
 Corpus tests in `tests/sqlparser_corpus.rs` parse real SQL from `tests/corpus/{dialect}/` directories:
 ```bash
-# Run corpus tests and track progress
-cargo nextest run --test sqlparser_corpus --no-fail-fast 2>&1 | grep "PASS" | wc -l
+# Run corpus tests with timestamped results and comparison
+./scripts/run-corpus-tests.sh --compare
 
-# Find common error patterns
-cargo nextest run --test sqlparser_corpus --no-fail-fast 2>&1 | grep "sql parser error:" | sort | uniq -c | sort -rn
+# Compare two specific reports
+node scripts/compare-corpus-reports.js target/corpus-report.json target/corpus-results/corpus-report-*.json
 
-# Debug specific corpus file
-cargo test --test sqlparser_corpus -- --nocapture dialect/category/hash
+# List saved reports
+ls -lht target/corpus-results/corpus-report-*.json
 ```
+
+**Corpus test infrastructure:**
+- Uses custom test harness (`harness = false` in Cargo.toml with libtest_mimic)
+- `customer_*` dialect prefixes are automatically stripped (customer_bigquery → bigquery)
+- Reports track individual test results for regression detection
+- See `scripts/README.md` for detailed usage
 
 ## Architecture
 
@@ -96,6 +102,7 @@ Each dialect module defines parsing behavior variations:
 - `GenericDialect` - Default baseline dialect
 - `AnsiDialect` - Strict ANSI SQL:2011
 - `SnowflakeDialect`, `PostgreSqlDialect`, `BigQueryDialect`, `MySqlDialect`, etc.
+- **Note**: `customer_*` prefixed dialects (e.g., `customer_bigquery`) map to their base dialect
 
 Dialects control:
 - Quote character handling for identifiers
@@ -189,6 +196,7 @@ Since this is a fork of apache/datafusion-sqlparser-rs:
 - Use `pretty_assertions` for readable diffs
 - Run `cargo fmt`, `cargo clippy`, `cargo nextest run` before submitting
 - CI runs: `cargo check`, `cargo nextest run --all-features`
+- Avoid adding serde dependency to test code - use manual JSON building if needed
 
 ## Features (Cargo.toml)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,125 @@
+# Corpus Test Scripts
+
+Helper scripts for running and comparing corpus test results.
+
+## Quick Start
+
+### Run corpus tests and save results
+```bash
+./scripts/run-corpus-tests.sh
+```
+
+### Run and compare with previous run
+```bash
+./scripts/run-corpus-tests.sh --compare
+```
+
+### Compare two specific reports
+```bash
+node scripts/compare-corpus-reports.js target/corpus-report.json target/corpus-results/corpus-report-20260209-123456.json
+```
+
+## Scripts
+
+### `run-corpus-tests.sh`
+
+Runs the corpus test suite and saves timestamped results.
+
+**Usage:**
+```bash
+./scripts/run-corpus-tests.sh [--compare]
+```
+
+**What it does:**
+- Runs `cargo test --test sqlparser_corpus`
+- Saves results to `target/corpus-results/corpus-report-YYYYMMDD-HHMMSS.json`
+- Saves full test output to `target/corpus-results/corpus-run-YYYYMMDD-HHMMSS.log`
+- Shows summary (passed/failed counts, pass rate)
+- With `--compare`: automatically compares with most recent previous run
+
+**Example output:**
+```
+==> Running corpus tests...
+✅ Results saved to: target/corpus-results/corpus-report-20260209-143022.json
+
+==> Summary
+  Passed: 3284 / 3617 (90.8%)
+  Failed: 333
+```
+
+### `compare-corpus-reports.js`
+
+Generates a markdown comparison report between two corpus test runs.
+
+**Usage:**
+```bash
+node scripts/compare-corpus-reports.js <current-report.json> [baseline-report.json]
+```
+
+**What it does:**
+- Loads and compares two corpus test reports
+- Identifies:
+  - ❌ **Regressions**: tests that were passing, now failing
+  - ✅ **Improvements**: tests that were failing, now passing
+  - ➕ **New tests**: added to corpus
+  - ➖ **Removed tests**: removed from corpus
+- Generates markdown report with per-dialect statistics
+- If no baseline provided, shows only current stats
+
+**Example output:**
+```markdown
+## Corpus Parsing Report
+
+**Total: 3284 passed, 333 failed** (90.8% pass rate)
+
+### Changes
+
+❌ **2 regression(s)** (now failing)
+✅ **15 improvement(s)** (now passing)
+
+### By Dialect
+
+| Dialect | Passed | Failed | Total | Pass Rate | Delta |
+|---------|-------:|-------:|------:|----------:|------:|
+| bigquery | 1000 | 50 | 1050 | 95.2% | **+5** |
+...
+```
+
+## Tracking Progress
+
+### View all saved reports
+```bash
+ls -lht target/corpus-results/corpus-report-*.json
+```
+
+### Compare current work against main branch baseline
+```bash
+# Save current state
+./scripts/run-corpus-tests.sh
+
+# Checkout main and run tests
+git stash
+git checkout main
+./scripts/run-corpus-tests.sh
+
+# Return to your branch
+git checkout -
+git stash pop
+
+# Compare
+MAIN_REPORT=$(ls -t target/corpus-results/corpus-report-*.json | head -2 | tail -1)
+CURRENT_REPORT=$(ls -t target/corpus-results/corpus-report-*.json | head -1)
+node scripts/compare-corpus-reports.js $CURRENT_REPORT $MAIN_REPORT
+```
+
+## CI/CD Integration
+
+The GitHub Actions workflow (`.github/workflows/corpus.yml`) uses these scripts:
+
+1. Runs corpus tests
+2. Saves report to `target/corpus-report.json`
+3. Downloads baseline from main branch
+4. Runs `compare-corpus-reports.js` to generate comparison
+5. Posts markdown report as PR comment
+
+This ensures consistent reporting between local development and CI.

--- a/scripts/compare-corpus-reports.js
+++ b/scripts/compare-corpus-reports.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Compare two corpus test reports and generate a markdown summary.
+ *
+ * Usage:
+ *   node scripts/compare-corpus-reports.js <current-report.json> [baseline-report.json]
+ *
+ * If baseline is omitted, only shows current stats without comparison.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function loadReport(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (e) {
+    console.error(`Error loading ${filePath}: ${e.message}`);
+    return null;
+  }
+}
+
+function generateReport(current, baseline = null) {
+  let body = '## Corpus Parsing Report\n\n';
+
+  const totalTests = current.summary.total_tests;
+  const passRate = (current.summary.total_passed / totalTests * 100).toFixed(1);
+  body += `**Total: ${current.summary.total_passed} passed, ${current.summary.total_failed} failed** (${passRate}% pass rate)\n\n`;
+
+  let hasBaseline = baseline !== null;
+  let regressions = [];
+  let improvements = [];
+  let removed = [];
+  let added = [];
+
+  if (hasBaseline) {
+    // Detect changes by comparing individual test results
+    const baselineTests = baseline.test_results || {};
+    const currentTests = current.test_results || {};
+
+    for (const [test, status] of Object.entries(currentTests)) {
+      if (baselineTests[test] === 'pass' && status === 'fail') {
+        regressions.push(test);
+      } else if (baselineTests[test] === 'fail' && status === 'pass') {
+        improvements.push(test);
+      } else if (!baselineTests[test]) {
+        added.push(test);
+      }
+    }
+
+    for (const test of Object.keys(baselineTests)) {
+      if (!currentTests[test]) {
+        removed.push(test);
+      }
+    }
+
+    // Show regressions and improvements summary
+    if (regressions.length > 0 || improvements.length > 0 || removed.length > 0 || added.length > 0) {
+      body += '### Changes\n\n';
+      if (regressions.length > 0) {
+        body += `❌ **${regressions.length} regression(s)** (now failing)\n`;
+      }
+      if (improvements.length > 0) {
+        body += `✅ **${improvements.length} improvement(s)** (now passing)\n`;
+      }
+      if (added.length > 0) {
+        body += `➕ **${added.length} new test(s)**\n`;
+      }
+      if (removed.length > 0) {
+        body += `➖ **${removed.length} removed test(s)**\n`;
+      }
+      body += '\n';
+    } else {
+      body += '**✨ No changes in test results**\n\n';
+    }
+  }
+
+  // Per-dialect table
+  body += '### By Dialect\n\n';
+  body += '| Dialect | Passed | Failed | Total | Pass Rate |';
+  if (hasBaseline) body += ' Delta |';
+  body += '\n';
+
+  body += '|---------|-------:|-------:|------:|----------:|';
+  if (hasBaseline) body += '------:|';
+  body += '\n';
+
+  for (const [dialect, stats] of Object.entries(current.by_dialect)) {
+    const total = stats.passed + stats.failed;
+    const rate = (stats.passed / total * 100).toFixed(1);
+    body += `| ${dialect} | ${stats.passed} | ${stats.failed} | ${total} | ${rate}% |`;
+
+    if (hasBaseline && baseline.by_dialect && baseline.by_dialect[dialect]) {
+      const base = baseline.by_dialect[dialect];
+      const diff = stats.passed - base.passed;
+      if (diff > 0) body += ` **+${diff}** |`;
+      else if (diff < 0) body += ` **${diff}** |`;
+      else body += ` - |`;
+    } else if (hasBaseline) {
+      body += ` *new* |`;
+    }
+
+    body += '\n';
+  }
+
+  // Show details for regressions and improvements
+  if (hasBaseline) {
+    const maxShow = 10;
+
+    if (regressions.length > 0) {
+      body += '\n<details>\n<summary>❌ Regressions (' + regressions.length + ')</summary>\n\n';
+      body += '```\n';
+      for (const test of regressions.slice(0, maxShow)) {
+        body += test + '\n';
+      }
+      if (regressions.length > maxShow) {
+        body += `... and ${regressions.length - maxShow} more\n`;
+      }
+      body += '```\n</details>\n';
+    }
+
+    if (improvements.length > 0) {
+      body += '\n<details>\n<summary>✅ Improvements (' + improvements.length + ')</summary>\n\n';
+      body += '```\n';
+      for (const test of improvements.slice(0, maxShow)) {
+        body += test + '\n';
+      }
+      if (improvements.length > maxShow) {
+        body += `... and ${improvements.length - maxShow} more\n`;
+      }
+      body += '```\n</details>\n';
+    }
+
+    if (added.length > 0) {
+      body += '\n<details>\n<summary>➕ New Tests (' + added.length + ')</summary>\n\n';
+      body += '```\n';
+      for (const test of added.slice(0, maxShow)) {
+        body += test + '\n';
+      }
+      if (added.length > maxShow) {
+        body += `... and ${added.length - maxShow} more\n`;
+      }
+      body += '```\n</details>\n';
+    }
+
+    if (removed.length > 0) {
+      body += '\n<details>\n<summary>➖ Removed Tests (' + removed.length + ')</summary>\n\n';
+      body += '```\n';
+      for (const test of removed.slice(0, maxShow)) {
+        body += test + '\n';
+      }
+      if (removed.length > maxShow) {
+        body += `... and ${removed.length - maxShow} more\n`;
+      }
+      body += '```\n</details>\n';
+    }
+  } else {
+    body += '\n*No baseline available for comparison*\n';
+  }
+
+  return body;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 1) {
+    console.error('Usage: node compare-corpus-reports.js <current-report.json> [baseline-report.json]');
+    process.exit(1);
+  }
+
+  const currentPath = args[0];
+  const baselinePath = args[1];
+
+  const current = loadReport(currentPath);
+  if (!current) {
+    console.error('Failed to load current report');
+    process.exit(1);
+  }
+
+  const baseline = baselinePath ? loadReport(baselinePath) : null;
+
+  const report = generateReport(current, baseline);
+  console.log(report);
+}
+
+if (require.main === module) {
+  main();
+}
+
+// Export for use in GitHub Actions
+module.exports = { generateReport, loadReport };

--- a/scripts/run-corpus-tests.sh
+++ b/scripts/run-corpus-tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# Run corpus tests and store results with timestamp
+# Usage: ./scripts/run-corpus-tests.sh [--compare]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESULTS_DIR="$REPO_ROOT/target/corpus-results"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUTPUT_FILE="$RESULTS_DIR/corpus-report-$TIMESTAMP.json"
+
+# Parse arguments
+COMPARE=false
+if [ "$1" = "--compare" ]; then
+    COMPARE=true
+fi
+
+echo "==> Running corpus tests..."
+cd "$REPO_ROOT"
+
+# Run tests (continue on error to get partial results)
+cargo test --test sqlparser_corpus 2>&1 | tee "$RESULTS_DIR/corpus-run-$TIMESTAMP.log" || true
+
+# Check if report was generated
+if [ ! -f "$REPO_ROOT/target/corpus-report.json" ]; then
+    echo "❌ Error: corpus-report.json not generated"
+    exit 1
+fi
+
+# Create results directory if it doesn't exist
+mkdir -p "$RESULTS_DIR"
+
+# Copy report to timestamped file
+cp "$REPO_ROOT/target/corpus-report.json" "$OUTPUT_FILE"
+
+echo ""
+echo "✅ Results saved to: $OUTPUT_FILE"
+
+# Show summary
+PASSED=$(jq -r '.summary.total_passed' "$OUTPUT_FILE")
+FAILED=$(jq -r '.summary.total_failed' "$OUTPUT_FILE")
+TOTAL=$(jq -r '.summary.total_tests' "$OUTPUT_FILE")
+PASS_RATE=$(echo "scale=1; $PASSED * 100 / $TOTAL" | bc)
+
+echo ""
+echo "==> Summary"
+echo "  Passed: $PASSED / $TOTAL ($PASS_RATE%)"
+echo "  Failed: $FAILED"
+
+# Compare with previous run if requested
+if [ "$COMPARE" = true ]; then
+    # Find the most recent previous report (excluding current one)
+    PREV_REPORT=$(find "$RESULTS_DIR" -name "corpus-report-*.json" -type f ! -name "corpus-report-$TIMESTAMP.json" | sort -r | head -1)
+
+    if [ -n "$PREV_REPORT" ]; then
+        PREV_TIMESTAMP=$(basename "$PREV_REPORT" | sed 's/corpus-report-\(.*\)\.json/\1/')
+        echo ""
+        echo "==> Comparing with previous run ($PREV_TIMESTAMP)"
+        echo ""
+        node "$SCRIPT_DIR/compare-corpus-reports.js" "$OUTPUT_FILE" "$PREV_REPORT"
+    else
+        echo ""
+        echo "ℹ️  No previous report found for comparison"
+    fi
+fi
+
+echo ""
+echo "To compare with a specific run:"
+echo "  node scripts/compare-corpus-reports.js $OUTPUT_FILE <baseline-report.json>"
+echo ""
+echo "To list all saved reports:"
+echo "  ls -lht $RESULTS_DIR/corpus-report-*.json"


### PR DESCRIPTION
## Summary
Enhances the corpus test infrastructure with detailed regression tracking and local testing tools.

## Changes

### Fixed
- **Panic with customer_* dialects**: Strip `customer_` prefix from dialect names (customer_bigquery → bigquery)

### Improved Reporting
**Before**: Only aggregate counts per dialect
```json
{
  "total_passed": 3284,
  "total_failed": 333,
  "dialects": { "bigquery": {"passed": 100, "failed": 20} }
}
```

**After**: Individual test tracking
```json
{
  "summary": { "total_passed": 3284, "total_failed": 333, "total_tests": 3617 },
  "by_dialect": { "bigquery": {"passed": 100, "failed": 20} },
  "test_results": { "bigquery/abc123.sql": "pass", "bigquery/def456.sql": "fail" }
}
```

### Regression Detection
The new format enables accurate tracking:
- ❌ **Regressions**: Tests that were passing, now failing
- ✅ **Improvements**: Tests that were failing, now passing  
- ➕ **New tests**: Added to corpus
- ➖ **Removed tests**: Removed from corpus

**Problem solved**: Fixing 10 minor tests and breaking 9 major tests no longer shows as "+1 improvement" — it correctly shows as "9 regressions, 10 improvements"

### New Scripts

#### `scripts/compare-corpus-reports.js`
Generate markdown comparison between two reports:
```bash
node scripts/compare-corpus-reports.js current.json baseline.json
```

#### `scripts/run-corpus-tests.sh`
Run tests with timestamped results:
```bash
./scripts/run-corpus-tests.sh --compare
```

Saves to `target/corpus-results/corpus-report-YYYYMMDD-HHMMSS.json`

### CI/CD Integration
Updated GitHub workflow to use the standalone script, ensuring same logic runs locally and in CI.

## Testing
- [x] Scripts tested locally
- [x] Comparison logic verified
- [x] customer_* dialects now parse correctly
- [x] Report format validated

## Documentation
Added `scripts/README.md` with usage examples and workflow explanations.