### PR TITLE
fix(snowflake): support implicit statement boundaries without semicolons

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -144,6 +144,14 @@ pub trait Dialect: Debug + Any {
     fn supports_from_first_select(&self) -> bool {
         false
     }
+    /// Returns true if the dialect allows multiple statements without semicolons.
+    /// When enabled, the parser treats any valid statement-starting token after a
+    /// completed statement as an implicit boundary, rather than requiring `;`.
+    /// This handles real-world SQL from sources like Snowflake's GET_DDL() which
+    /// can concatenate statements without delimiters.
+    fn supports_implicit_statement_boundaries(&self) -> bool {
+        false
+    }
     /// Dialect-specific prefix parser override
     fn parse_prefix(&self, _parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
         // return None to fall back to the default behavior
@@ -329,6 +337,10 @@ mod tests {
 
             fn supports_prefix_alias_colon(&self) -> bool {
                 self.0.supports_prefix_alias_colon()
+            }
+
+            fn supports_implicit_statement_boundaries(&self) -> bool {
+                self.0.supports_implicit_statement_boundaries()
             }
 
             fn supports_from_first_select(&self) -> bool {

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -49,6 +49,10 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    fn supports_implicit_statement_boundaries(&self) -> bool {
+        true
+    }
+
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::CREATE) {
             // possibly CREATE STAGE

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -874,6 +874,16 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::MATCH_CONDITION,
     // for MySQL STRAIGHT_JOIN
     Keyword::STRAIGHT_JOIN,
+    // Statement-starting keywords must not be parsed as table aliases
+    Keyword::INSERT,
+    Keyword::CREATE,
+    Keyword::DELETE,
+    Keyword::UPDATE,
+    Keyword::ALTER,
+    Keyword::DROP,
+    Keyword::GRANT,
+    Keyword::REVOKE,
+    Keyword::MERGE,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`
@@ -912,4 +922,14 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
     // for Snowflake START WITH .. CONNECT BY hierarchical queries
     Keyword::START,
     Keyword::CONNECT,
+    // Statement-starting keywords must not be parsed as column aliases
+    Keyword::INSERT,
+    Keyword::CREATE,
+    Keyword::DELETE,
+    Keyword::UPDATE,
+    Keyword::ALTER,
+    Keyword::DROP,
+    Keyword::GRANT,
+    Keyword::REVOKE,
+    Keyword::MERGE,
 ];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -493,7 +493,11 @@ impl<'a> Parser<'a> {
             }
 
             if expecting_statement_delimiter {
-                return self.expected("end of statement", self.peek_token());
+                if self.dialect.supports_implicit_statement_boundaries() {
+                    expecting_statement_delimiter = false;
+                } else {
+                    return self.expected("end of statement", self.peek_token());
+                }
             }
 
             let statement = self.parse_statement()?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -196,7 +196,10 @@ fn parse_update() {
     );
 
     let sql = "UPDATE t SET a = 1 extrabadstuff";
-    let res = parse_sql_statements(sql);
+    let no_implicit_boundaries = all_dialects_except(|d| {
+        d.supports_implicit_statement_boundaries()
+    });
+    let res = no_implicit_boundaries.parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: extrabadstuff\nNear ` t SET a = 1`"
@@ -824,7 +827,10 @@ fn parse_select_into() {
 
     // Do not allow aliases here
     let sql = "SELECT * INTO table0 asdf FROM table1";
-    let result = parse_sql_statements(sql);
+    let no_implicit_boundaries = all_dialects_except(|d| {
+        d.supports_implicit_statement_boundaries()
+    });
+    let result = no_implicit_boundaries.parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: asdf\nNear `SELECT * INTO table0`"
@@ -867,7 +873,10 @@ fn parse_select_wildcard() {
     );
 
     let sql = "SELECT * + * FROM foo;";
-    let result = parse_sql_statements(sql);
+    let no_implicit_boundaries = all_dialects_except(|d| {
+        d.supports_implicit_statement_boundaries()
+    });
+    let result = no_implicit_boundaries.parse_sql_statements(sql);
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: +\nNear `SELECT *`"
@@ -1016,7 +1025,8 @@ fn parse_not() {
 
 #[test]
 fn parse_invalid_infix_not() {
-    let res = parse_sql_statements("SELECT c FROM t WHERE c NOT (");
+    let res = all_dialects_except(|d| d.supports_implicit_statement_boundaries())
+        .parse_sql_statements("SELECT c FROM t WHERE c NOT (");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: NOT\nNear ` c FROM t WHERE c`"
@@ -3830,7 +3840,11 @@ fn parse_alter_table_drop_constraint() {
         _ => unreachable!(),
     }
 
-    let res = parse_sql_statements(&format!("{alter_stmt} DROP CONSTRAINT is_active TEXT"));
+    let no_implicit_boundaries = all_dialects_except(|d| {
+        d.supports_implicit_statement_boundaries()
+    });
+    let res = no_implicit_boundaries
+        .parse_sql_statements(&format!("{alter_stmt} DROP CONSTRAINT is_active TEXT"));
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: TEXT\nNear ` TABLE tab DROP CONSTRAINT is_active`"
@@ -4468,7 +4482,8 @@ fn parse_interval() {
         expr_from_projection(only(&select.projection)),
     );
 
-    let result = parse_sql_statements("SELECT INTERVAL '1' SECOND TO SECOND");
+    let no_implicit = all_dialects_except(|d| d.supports_implicit_statement_boundaries());
+    let result = no_implicit.parse_sql_statements("SELECT INTERVAL '1' SECOND TO SECOND");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: SECOND\nNear `SELECT INTERVAL '1' SECOND TO`"
@@ -4478,7 +4493,7 @@ fn parse_interval() {
         result.unwrap_err(),
     );
 
-    let result = parse_sql_statements("SELECT INTERVAL '10' HOUR (1) TO HOUR (2)");
+    let result = no_implicit.parse_sql_statements("SELECT INTERVAL '10' HOUR (1) TO HOUR (2)");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: (\nNear `HOUR (1) TO HOUR `"
@@ -5807,8 +5822,13 @@ fn parse_multiple_statements() {
         );
         // Check that extra semicolon at the end is stripped by normalization:
         one_statement_parses_to(&(sql1.to_owned() + ";"), sql1);
-        // Check that forgetting the semicolon results in an error:
-        let res = parse_sql_statements(&(sql1.to_owned() + " " + sql2_kw + sql2_rest));
+        // Check that forgetting the semicolon results in an error for dialects
+        // that don't support implicit statement boundaries:
+        let no_implicit_boundaries = all_dialects_except(|d| {
+            d.supports_implicit_statement_boundaries()
+        });
+        let res = no_implicit_boundaries
+            .parse_sql_statements(&(sql1.to_owned() + " " + sql2_kw + sql2_rest));
 
         let actual = format!("{}", res.unwrap_err());
         let expected = format!("Expected end of statement, found: {}", sql2_kw.to_string());
@@ -6569,7 +6589,8 @@ fn parse_drop_view() {
 
 #[test]
 fn parse_invalid_subquery_without_parens() {
-    let res = parse_sql_statements("SELECT SELECT 1 FROM bar WHERE 1=1 FROM baz");
+    let res = all_dialects_except(|d| d.supports_implicit_statement_boundaries())
+        .parse_sql_statements("SELECT SELECT 1 FROM bar WHERE 1=1 FROM baz");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: 1\nNear `SELECT SELECT `"
@@ -6860,7 +6881,10 @@ fn parse_start_transaction() {
         res.unwrap_err()
     );
 
-    let res = parse_sql_statements("START TRANSACTION BAD");
+    let no_implicit_boundaries = all_dialects_except(|d| {
+        d.supports_implicit_statement_boundaries()
+    });
+    let res = no_implicit_boundaries.parse_sql_statements("START TRANSACTION BAD");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: BAD\nNear `START TRANSACTION`"
@@ -7855,7 +7879,8 @@ fn parse_offset_and_limit() {
     );
 
     // Can't repeat OFFSET / LIMIT
-    let res = parse_sql_statements("SELECT foo FROM bar OFFSET 2 OFFSET 2");
+    let no_implicit = all_dialects_except(|d| d.supports_implicit_statement_boundaries());
+    let res = no_implicit.parse_sql_statements("SELECT foo FROM bar OFFSET 2 OFFSET 2");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: OFFSET\nNear ` foo FROM bar OFFSET 2`"
@@ -7865,7 +7890,7 @@ fn parse_offset_and_limit() {
         res.unwrap_err()
     );
 
-    let res = parse_sql_statements("SELECT foo FROM bar LIMIT 2 LIMIT 2");
+    let res = no_implicit.parse_sql_statements("SELECT foo FROM bar LIMIT 2 LIMIT 2");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: LIMIT\nNear ` foo FROM bar LIMIT 2`"
@@ -7875,7 +7900,7 @@ fn parse_offset_and_limit() {
         res.unwrap_err()
     );
 
-    let res = parse_sql_statements("SELECT foo FROM bar OFFSET 2 LIMIT 2 OFFSET 2");
+    let res = no_implicit.parse_sql_statements("SELECT foo FROM bar OFFSET 2 LIMIT 2 OFFSET 2");
     assert_eq!(
         ParserError::ParserError(
             "Expected end of statement, found: OFFSET\nNear ` bar OFFSET 2 LIMIT 2`"

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -569,8 +569,14 @@ fn test_select_wildcard_with_exclude_and_rename() {
     assert_eq!(expected, select.projection[0]);
 
     // rename cannot precede exclude
+    // Only test with GenericDialect since Snowflake supports implicit statement
+    // boundaries and won't produce "Expected end of statement" errors.
+    let generic_only = TestedDialects {
+        dialects: vec![Box::new(GenericDialect {})],
+        options: None,
+    };
     assert_eq!(
-        snowflake_and_generic()
+        generic_only
             .parse_sql_statements("SELECT * RENAME col_a AS col_b EXCLUDE col_z FROM data")
             .unwrap_err()
             .to_string(),
@@ -2178,4 +2184,21 @@ fn test_snowflake_connect_by() {
     snowflake_and_generic().verified_stmt(
         "WITH hier AS (SELECT col_id, CONNECT_BY_ROOT col_id AS root_id FROM tbl START WITH col_parent_id IS NULL CONNECT BY col_parent_id = PRIOR col_id) SELECT * FROM hier",
     );
+}
+
+#[test]
+fn test_implicit_statement_boundaries() {
+    // Snowflake GET_DDL() can produce multi-statement SQL without semicolons.
+    // The parser should handle this by treating statement-starting keywords
+    // as implicit boundaries after a completed statement.
+    let sql = concat!(
+        "CREATE OR REPLACE VIEW db.sch.v1 AS ",
+        "SELECT a, b FROM db.sch.t1 ",
+        "UNION ALL ",
+        "SELECT a, b FROM db.sch.t2 ",
+        "INSERT INTO db.sch.t3 (a, b) ",
+        "SELECT a, b FROM db.sch.v1"
+    );
+    let stmts = snowflake().parse_sql_statements(sql).unwrap();
+    assert_eq!(stmts.len(), 2);
 }


### PR DESCRIPTION
## Summary

- Snowflake's `GET_DDL('SCHEMA', ...)` can produce multi-statement SQL without semicolons between them
- This caused "Expected end of statement, found: INSERT" errors when parsing concatenated CREATE VIEW + INSERT statements
- Adds `supports_implicit_statement_boundaries()` dialect trait method, enabled for Snowflake only
- Reserves statement-starting keywords (INSERT, CREATE, DELETE, UPDATE, ALTER, DROP, GRANT, REVOKE, MERGE) as table/column aliases to prevent incorrect alias parsing