### PR TITLE
ci: add slack-pr-react workflow for Slack PR emoji updates

### DIFF
--- a/.github/workflows/smackr.yaml
+++ b/.github/workflows/smackr.yaml
@@ -1,0 +1,17 @@
+name: Slack emoji PR updates
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
+
+jobs:
+  smackr:
+    # Skip fork PRs to avoid leaking secrets
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsynq/smackr@v1
+        with:
+          slack-api-token: ${{ secrets.SLAPR_API_TOKEN }}

--- a/.github/workflows/smackr.yaml
+++ b/.github/workflows/smackr.yaml
@@ -7,11 +7,13 @@ on:
     types: [closed]
 
 jobs:
-  smackr:
+  slack-pr-react:
     # Skip fork PRs to avoid leaking secrets
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: getsynq/smackr@v1
+      - uses: getsynq/slack-pr-react@v1
         with:
-          slack-api-token: ${{ secrets.SLAPR_API_TOKEN }}
+          slack-api-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          slack-app-id: ${{ vars.SLACK_APP_ID }}


### PR DESCRIPTION
Add slack-pr-react workflow to sync Slack emoji reactions on PR messages based on review status. Includes fork PR guard since this is a public repo.