### PR TITLE
Route Snowflake SECURE / DYNAMIC / HYBRID / ICEBERG DDL through CreateView/CreateTable/CreateFunction

### DIFF
--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -53,6 +53,9 @@ pub struct CreateTableBuilder {
     pub global: Option<bool>,
     pub if_not_exists: bool,
     pub transient: bool,
+    pub dynamic: bool,
+    pub iceberg: bool,
+    pub hybrid: bool,
     pub name: ObjectName,
     pub columns: Vec<ColumnDef>,
     pub constraints: Vec<TableConstraint>,
@@ -104,6 +107,9 @@ impl CreateTableBuilder {
             global: None,
             if_not_exists: false,
             transient: false,
+            dynamic: false,
+            iceberg: false,
+            hybrid: false,
             name,
             columns: vec![],
             constraints: vec![],
@@ -173,6 +179,21 @@ impl CreateTableBuilder {
 
     pub fn transient(mut self, transient: bool) -> Self {
         self.transient = transient;
+        self
+    }
+
+    pub fn dynamic(mut self, dynamic: bool) -> Self {
+        self.dynamic = dynamic;
+        self
+    }
+
+    pub fn iceberg(mut self, iceberg: bool) -> Self {
+        self.iceberg = iceberg;
+        self
+    }
+
+    pub fn hybrid(mut self, hybrid: bool) -> Self {
+        self.hybrid = hybrid;
         self
     }
 
@@ -377,6 +398,9 @@ impl CreateTableBuilder {
             global: self.global,
             if_not_exists: self.if_not_exists,
             transient: self.transient,
+            dynamic: self.dynamic,
+            iceberg: self.iceberg,
+            hybrid: self.hybrid,
             name: self.name,
             columns: self.columns,
             constraints: self.constraints,
@@ -435,6 +459,9 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 global,
                 if_not_exists,
                 transient,
+                dynamic,
+                iceberg,
+                hybrid,
                 name,
                 columns,
                 constraints,
@@ -482,6 +509,9 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 global,
                 if_not_exists,
                 transient,
+                dynamic,
+                iceberg,
+                hybrid,
                 name,
                 columns,
                 constraints,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2294,6 +2294,8 @@ pub enum Statement {
         comment: Option<String>,
         /// Optional parameters.
         params: CreateFunctionBody,
+        /// Snowflake `SECURE` modifier: `CREATE SECURE FUNCTION ...`.
+        secure: bool,
     },
     /// ```sql
     /// CREATE PROCEDURE
@@ -2994,12 +2996,14 @@ impl fmt::Display for Statement {
                 return_type,
                 comment,
                 params,
+                secure,
             } => {
                 write!(
                     f,
-                    "CREATE {or_replace}{temp}{table}FUNCTION {name}",
+                    "CREATE {or_replace}{secure}{temp}{table}FUNCTION {name}",
                     temp = if *temporary { "TEMPORARY " } else { "" },
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                    secure = if *secure { "SECURE " } else { "" },
                     table = if *table_function { "TABLE " } else { "" },
                 )?;
                 if let Some(args) = args {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1815,6 +1815,8 @@ pub enum Statement {
         view_options: Vec<SqlOption>,
         copy_grants: bool,
         view_security: Option<ViewSecurity>,
+        /// Snowflake `SECURE` modifier: `CREATE SECURE VIEW ...` / `CREATE SECURE MATERIALIZED VIEW ...`
+        secure: bool,
     },
     /// ```sql
     /// CREATE TABLE
@@ -3080,11 +3082,13 @@ impl fmt::Display for Statement {
                 view_options,
                 copy_grants,
                 view_security,
+                secure,
             } => {
                 write!(
                     f,
-                    "CREATE {or_replace}{materialized}VIEW {if_not_exists}{name}",
+                    "CREATE {or_replace}{secure}{materialized}VIEW {if_not_exists}{name}",
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                    secure = if *secure { "SECURE " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     materialized = if *materialized { "MATERIALIZED " } else { "" },
                     name = name

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1828,6 +1828,14 @@ pub enum Statement {
         global: Option<bool>,
         if_not_exists: bool,
         transient: bool,
+        /// Snowflake `CREATE DYNAMIC TABLE`. Dynamic tables carry their own option set
+        /// (TARGET_LAG, WAREHOUSE, REFRESH_MODE, INITIALIZE, …) surfaced in
+        /// `table_options` so visitors see the referenced warehouse / source tables.
+        dynamic: bool,
+        /// Snowflake `CREATE ICEBERG TABLE` or `CREATE DYNAMIC ICEBERG TABLE`.
+        iceberg: bool,
+        /// Snowflake Unistore `CREATE HYBRID TABLE`.
+        hybrid: bool,
         /// Table name
         #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
         name: ObjectName,
@@ -3215,6 +3223,9 @@ impl fmt::Display for Statement {
                 inherits,
                 partition_of,
                 partition_bound,
+                dynamic,
+                iceberg,
+                hybrid,
             } => {
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:
@@ -3225,7 +3236,7 @@ impl fmt::Display for Statement {
                 //   `CREATE TABLE t (a INT) AS SELECT a from t2`
                 write!(
                     f,
-                    "CREATE {or_replace}{external}{global}{temporary}{transient}TABLE {if_not_exists}{name}",
+                    "CREATE {or_replace}{external}{global}{temporary}{transient}{dynamic}{hybrid}{iceberg}TABLE {if_not_exists}{name}",
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     external = if *external { "EXTERNAL " } else { "" },
                     global = global
@@ -3240,6 +3251,9 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     temporary = if *temporary { "TEMPORARY " } else { "" },
                     transient = if *transient { "TRANSIENT " } else { "" },
+                    dynamic = if *dynamic { "DYNAMIC " } else { "" },
+                    hybrid = if *hybrid { "HYBRID " } else { "" },
+                    iceberg = if *iceberg { "ICEBERG " } else { "" },
                     name = name,
                 )?;
                 if let Some(on_cluster) = on_cluster {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6652,12 +6652,14 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_procedure_param(&mut self) -> Result<ProcedureParam, ParserError> {
-        // Redshift / Postgres-style procedures accept an optional IN/OUT/INOUT mode
-        // before the parameter name. MSSQL doesn't use these keywords here, but
-        // accepting them is harmless — `IN`/`OUT`/`INOUT` are not valid identifier
-        // starts for a parameter definition.
-        let mode = self.parse_arg_mode();
+        // Redshift / Postgres-style procedures accept an optional IN/OUT/INOUT mode.
+        // Postgres puts the mode before the name (`OUT argname type`); Redshift allows
+        // it after the name (`argname OUT type`). Accept both orders.
+        let mut mode = self.parse_arg_mode();
         let name = self.parse_identifier(false)?.unwrap();
+        if mode.is_none() {
+            mode = self.parse_arg_mode();
+        }
         let data_type = self.parse_data_type()?;
         let default_expr = if self.parse_keyword(Keyword::DEFAULT) || self.consume_token(&Token::Eq)
         {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4222,12 +4222,12 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(Keyword::EXTERNAL) {
             if self.parse_keyword(Keyword::FUNCTION) {
                 // Snowflake: CREATE EXTERNAL FUNCTION
-                self.parse_create_function(or_replace, temporary, false)
+                self.parse_create_function_inner(or_replace, temporary, false, secure)
             } else {
                 self.parse_create_external_table(or_replace)
             }
         } else if self.parse_keyword(Keyword::FUNCTION) {
-            self.parse_create_function(or_replace, temporary, false)
+            self.parse_create_function_inner(or_replace, temporary, false, secure)
         } else if self.parse_keyword(Keyword::MACRO) {
             self.parse_create_macro(or_replace, temporary)
         } else if self.parse_keyword(Keyword::INDEX) {
@@ -4652,6 +4652,16 @@ impl<'a> Parser<'a> {
         temporary: bool,
         table_function: bool,
     ) -> Result<Statement, ParserError> {
+        self.parse_create_function_inner(or_replace, temporary, table_function, false)
+    }
+
+    fn parse_create_function_inner(
+        &mut self,
+        or_replace: bool,
+        temporary: bool,
+        table_function: bool,
+        secure: bool,
+    ) -> Result<Statement, ParserError> {
         if dialect_of!(self is HiveDialect) {
             let name = self.parse_object_name(false)?;
             self.expect_keyword(Keyword::AS)?;
@@ -4671,6 +4681,7 @@ impl<'a> Parser<'a> {
                 return_type: None,
                 comment: None,
                 params,
+                secure,
             })
         } else if dialect_of!(self is ClickHouseDialect) {
             // ClickHouse: CREATE FUNCTION name AS (params) -> body
@@ -4691,6 +4702,7 @@ impl<'a> Parser<'a> {
                 return_type: None,
                 comment: None,
                 params,
+                secure,
             })
         } else if dialect_of!(self is PostgreSqlDialect | DatabricksDialect | BigQueryDialect | SnowflakeDialect | AnsiDialect | RedshiftSqlDialect | MsSqlDialect | MySqlDialect | SQLiteDialect | GenericDialect)
         {
@@ -4740,6 +4752,7 @@ impl<'a> Parser<'a> {
                 return_type,
                 comment,
                 params,
+                secure,
             })
         } else if dialect_of!(self is DuckDbDialect) {
             self.parse_create_macro(or_replace, temporary)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4199,6 +4199,48 @@ impl<'a> Parser<'a> {
             true
         };
         let transient = self.parse_one_of_keywords(&[Keyword::TRANSIENT]).is_some();
+        // Snowflake words that front TABLE: DYNAMIC (reserved keyword),
+        // HYBRID, ICEBERG (non-reserved). `DYNAMIC [ICEBERG] TABLE`,
+        // `HYBRID TABLE`, `ICEBERG TABLE`.
+        let peek_word_eq = |p: &mut Self, word: &str| -> bool {
+            matches!(
+                p.peek_token_kind(),
+                Token::Word(w) if w.value.eq_ignore_ascii_case(word)
+            )
+        };
+        let mut dynamic = false;
+        let mut hybrid = false;
+        let mut iceberg = false;
+        // Only consume these modifiers if TABLE follows (directly, or
+        // after ICEBERG for `DYNAMIC ICEBERG TABLE`).
+        let is_table_modifier = |p: &mut Self, word: &str, extra: bool| -> bool {
+            if !peek_word_eq(p, word) {
+                return false;
+            }
+            let n1 = p.peek_nth_token(1).token;
+            let table_next = matches!(&n1, Token::Word(w) if w.keyword == Keyword::TABLE);
+            if table_next {
+                return true;
+            }
+            if extra && matches!(&n1, Token::Word(w) if w.value.eq_ignore_ascii_case("ICEBERG")) {
+                let n2 = p.peek_nth_token(2).token;
+                return matches!(&n2, Token::Word(w) if w.keyword == Keyword::TABLE);
+            }
+            false
+        };
+        if is_table_modifier(self, "DYNAMIC", true) {
+            self.next_token();
+            dynamic = true;
+        } else if is_table_modifier(self, "HYBRID", false) {
+            self.next_token();
+            hybrid = true;
+        }
+        if peek_word_eq(self, "ICEBERG")
+            && matches!(self.peek_nth_token(1).token, Token::Word(ref w) if w.keyword == Keyword::TABLE)
+        {
+            self.next_token();
+            iceberg = true;
+        }
         let global: Option<bool> = if global {
             Some(true)
         } else if local {
@@ -4214,7 +4256,9 @@ impl<'a> Parser<'a> {
                 // CREATE TABLE FUNCTION (BigQuery table-valued function)
                 self.parse_create_function(or_replace, temporary, true)
             } else {
-                self.parse_create_table(or_replace, temporary, global, transient)
+                self.parse_create_table_inner(
+                    or_replace, temporary, global, transient, dynamic, iceberg, hybrid,
+                )
             }
         } else if self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW) {
             self.prev_token();
@@ -6007,6 +6051,21 @@ impl<'a> Parser<'a> {
         global: Option<bool>,
         transient: bool,
     ) -> Result<Statement, ParserError> {
+        self.parse_create_table_inner(
+            or_replace, temporary, global, transient, false, false, false,
+        )
+    }
+
+    pub fn parse_create_table_inner(
+        &mut self,
+        or_replace: bool,
+        temporary: bool,
+        global: Option<bool>,
+        transient: bool,
+        dynamic: bool,
+        iceberg: bool,
+        hybrid: bool,
+    ) -> Result<Statement, ParserError> {
         let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
         let table_name = self.parse_object_name(true)?;
 
@@ -6441,7 +6500,11 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            // KEY = VALUE dialect-specific options (DEFAULT_DDL_COLLATION, etc.)
+            // KEY = VALUE dialect-specific options (TARGET_LAG, WAREHOUSE,
+            // REFRESH_MODE, INITIALIZE, EXTERNAL_VOLUME, CATALOG, BASE_LOCATION,
+            // DEFAULT_DDL_COLLATION, etc.). Preserved into `table_options` so
+            // consumers (visitors / lineage) can read the referenced warehouse
+            // or catalog.
             if matches!(self.peek_token_kind().clone(), Token::Word(_))
                 && self.peek_nth_token(1).token == Token::Eq
                 // Don't consume AS = ... which could be something else
@@ -6450,7 +6513,11 @@ impl<'a> Parser<'a> {
                     Token::Word(ref w) if w.keyword == Keyword::AS
                 )
             {
-                self.next_token(); // keyword
+                let name_tok = self.next_token();
+                let key = match name_tok.token {
+                    Token::Word(w) => w.value,
+                    _ => unreachable!(),
+                };
                 self.next_token(); // =
                 if self.consume_token(&Token::LParen) {
                     let mut depth = 1i32;
@@ -6462,8 +6529,40 @@ impl<'a> Parser<'a> {
                             _ => {}
                         }
                     }
-                } else {
-                    let _ = self.parse_expr();
+                    // Value was a paren group; skip preserving since we don't have AST for it.
+                } else if let Ok(value) = self.parse_expr() {
+                    table_options.push(SqlOption {
+                        name: ObjectName(vec![Ident::new(key)]),
+                        value,
+                    });
+                }
+                continue;
+            }
+
+            // Snowflake Dynamic Table: REQUIRE USER (no value) and
+            // IMMUTABLE WHERE (<expr>). Consume but don't fail.
+            if dynamic
+                && matches!(
+                    self.peek_token_kind(),
+                    Token::Word(w) if w.value.eq_ignore_ascii_case("REQUIRE")
+                )
+            {
+                self.next_token(); // REQUIRE
+                let _ = self.next_token(); // USER/role
+                continue;
+            }
+            if dynamic && self.parse_keyword(Keyword::IMMUTABLE) {
+                if self.parse_keyword(Keyword::WHERE) {
+                    self.expect_token(&Token::LParen)?;
+                    let mut depth = 1i32;
+                    while depth > 0 {
+                        match self.next_token().token {
+                            Token::LParen => depth += 1,
+                            Token::RParen => depth -= 1,
+                            Token::EOF => break,
+                            _ => {}
+                        }
+                    }
                 }
                 continue;
             }
@@ -6574,6 +6673,24 @@ impl<'a> Parser<'a> {
             None
         };
 
+        // Snowflake: trailing `COPY GRANTS` after the `AS <query>` body.
+        if !copy_grants && self.parse_keywords(&[Keyword::COPY, Keyword::GRANTS]) {
+            copy_grants = true;
+        }
+        // If the query parser absorbed `COPY` as a table alias (it's not a
+        // reserved alias keyword), we'll be sitting on GRANTS now — treat that
+        // as the trailing COPY GRANTS modifier. The alias stays on the AST
+        // (harmless for lineage) but the statement parses cleanly.
+        if !copy_grants
+            && matches!(
+                self.peek_token_kind(),
+                Token::Word(w) if w.keyword == Keyword::GRANTS
+            )
+        {
+            self.next_token();
+            copy_grants = true;
+        }
+
         Ok(CreateTableBuilder::new(table_name)
             .temporary(temporary)
             .columns(columns)
@@ -6583,6 +6700,9 @@ impl<'a> Parser<'a> {
             .or_replace(or_replace)
             .if_not_exists(if_not_exists)
             .transient(transient)
+            .dynamic(dynamic)
+            .iceberg(iceberg)
+            .hybrid(hybrid)
             .hive_distribution(hive_distribution)
             .hive_formats(Some(hive_formats))
             .dist_style(dist_style)
@@ -6718,11 +6838,31 @@ impl<'a> Parser<'a> {
 
     pub fn parse_column_def(&mut self) -> Result<ColumnDef, ParserError> {
         let name = self.parse_identifier(false)?;
-        // Handle missing data type (e.g., `ADD COLUMN id;`)
+        // Handle missing data type (e.g., `ADD COLUMN id;`, or Snowflake
+        // `CREATE DYNAMIC TABLE t (col COMMENT '...', col TAG (...))` which lists
+        // bare column names with optional COMMENT/TAG but no type).
+        let next_kw_implies_no_type = matches!(
+            self.peek_token_kind(),
+            Token::Word(w) if matches!(
+                w.keyword,
+                Keyword::COMMENT
+                    | Keyword::TAG
+                    | Keyword::DEFAULT
+                    | Keyword::NOT
+                    | Keyword::NULL
+                    | Keyword::CONSTRAINT
+                    | Keyword::PRIMARY
+                    | Keyword::UNIQUE
+                    | Keyword::REFERENCES
+                    | Keyword::CHECK
+                    | Keyword::COLLATE
+            )
+        );
         let data_type = if self.peek_token_is(&Token::SemiColon)
             || self.peek_token_is(&Token::EOF)
             || self.peek_token().token == Token::Comma
             || self.peek_token().token == Token::RParen
+            || next_kw_implies_no_type
         {
             DataType::Unspecified
         } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4188,6 +4188,16 @@ impl<'a> Parser<'a> {
         let or_alter = self.parse_keywords(&[Keyword::OR, Keyword::ALTER]);
         let local = self.parse_one_of_keywords(&[Keyword::LOCAL]).is_some();
         let global = self.parse_one_of_keywords(&[Keyword::GLOBAL]).is_some();
+        // Snowflake `SECURE` modifier: precedes VIEW / MATERIALIZED VIEW / FUNCTION.
+        // It's not a reserved keyword, so peek for the word form before consuming.
+        let secure = matches!(
+            self.peek_token_kind(),
+            Token::Word(w) if w.keyword == Keyword::NoKeyword
+                && w.value.eq_ignore_ascii_case("SECURE")
+        ) && {
+            self.next_token();
+            true
+        };
         let transient = self.parse_one_of_keywords(&[Keyword::TRANSIENT]).is_some();
         let global: Option<bool> = if global {
             Some(true)
@@ -4208,7 +4218,7 @@ impl<'a> Parser<'a> {
             }
         } else if self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW) {
             self.prev_token();
-            self.parse_create_view(or_replace)
+            self.parse_create_view(or_replace, secure)
         } else if self.parse_keyword(Keyword::EXTERNAL) {
             if self.parse_keyword(Keyword::FUNCTION) {
                 // Snowflake: CREATE EXTERNAL FUNCTION
@@ -5033,7 +5043,11 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn parse_create_view(&mut self, or_replace: bool) -> Result<Statement, ParserError> {
+    pub fn parse_create_view(
+        &mut self,
+        or_replace: bool,
+        secure: bool,
+    ) -> Result<Statement, ParserError> {
         let materialized = self.parse_keyword(Keyword::MATERIALIZED);
         self.expect_keyword(Keyword::VIEW)?;
         let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
@@ -5337,6 +5351,7 @@ impl<'a> Parser<'a> {
             view_options,
             copy_grants,
             view_security,
+            secure,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6157,6 +6157,7 @@ fn parse_create_view() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<WithSpan<Ident>>::new(), columns);
@@ -6232,6 +6233,7 @@ fn parse_create_view_with_columns() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(false, if_not_exists);
             assert_eq!("v", name.to_string());
@@ -6291,6 +6293,7 @@ fn parse_create_view_if_not_exists() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(true, if_not_exists);
             assert_eq!("v", name.to_string());
@@ -6350,6 +6353,7 @@ fn parse_create_or_replace_view() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(false, if_not_exists);
             assert_eq!("v", name.to_string());
@@ -6407,6 +6411,7 @@ fn parse_create_or_replace_materialized_view() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(false, if_not_exists);
             assert_eq!("v", name.to_string());
@@ -6460,6 +6465,7 @@ fn parse_create_materialized_view() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(false, if_not_exists);
             assert_eq!("myschema.myview", name.to_string());
@@ -6513,6 +6519,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             view_options,
             copy_grants,
             view_security,
+            secure: _,
         } => {
             assert_eq!(false, if_not_exists);
             assert_eq!("myschema.myview", name.to_string());

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3553,6 +3553,7 @@ fn parse_create_function() {
                 )),
                 ..Default::default()
             },
+            secure: false,
         }
     );
 
@@ -3585,6 +3586,7 @@ fn parse_create_function() {
                 }),
                 ..Default::default()
             },
+            secure: false,
         }
     );
 
@@ -3614,6 +3616,7 @@ fn parse_create_function() {
                 using: None,
                 strict: false,
             },
+            secure: false,
         }
     );
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -656,6 +656,18 @@ fn test_redshift_create_procedure_trailing_clauses() {
 }
 
 #[test]
+fn test_redshift_create_procedure_argname_before_mode() {
+    // Redshift allows the argument mode (IN/OUT/INOUT) to appear *after* the
+    // parameter name: `argname argmode argtype`. Postgres puts the mode first.
+    // Both orders should parse.
+    let sql = "CREATE OR REPLACE PROCEDURE select_into_null(return_webpage OUT VARCHAR(256)) AS $$ BEGIN NULL; END; $$ LANGUAGE plpgsql";
+    redshift().parse_sql_statements(sql).unwrap();
+
+    let sql = "CREATE OR REPLACE PROCEDURE sp_get_credentials(userid INT, o_creds OUT VARCHAR) AS $$ BEGIN NULL; END; $$ LANGUAGE plpgsql";
+    redshift().parse_sql_statements(sql).unwrap();
+}
+
+#[test]
 fn test_redshift_column_encode() {
     // Redshift: CREATE TABLE with per-column ENCODE <encoding>
     redshift().verified_stmt("CREATE TABLE t (a INT ENCODE AZ64, b VARCHAR(10) ENCODE LZO)");

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2472,3 +2472,23 @@ fn test_snowflake_create_secure_materialized_view() {
         other => panic!("expected CreateView, got {other:?}"),
     }
 }
+
+#[test]
+fn test_snowflake_create_secure_function() {
+    // Snowflake `SECURE` modifier on CREATE FUNCTION must set CreateFunction { secure: true, .. }.
+    let sql = "CREATE OR REPLACE SECURE FUNCTION safe_div(a NUMBER, b NUMBER) RETURNS NUMBER AS $$ CASE WHEN b = 0 THEN NULL ELSE a / b END $$";
+    let stmt = snowflake().verified_stmt(sql);
+    match stmt {
+        Statement::CreateFunction {
+            secure,
+            or_replace,
+            name,
+            ..
+        } => {
+            assert!(secure);
+            assert!(or_replace);
+            assert_eq!(name.to_string(), "safe_div");
+        }
+        other => panic!("expected CreateFunction, got {other:?}"),
+    }
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2492,3 +2492,82 @@ fn test_snowflake_create_secure_function() {
         other => panic!("expected CreateFunction, got {other:?}"),
     }
 }
+
+#[test]
+fn test_snowflake_create_dynamic_table() {
+    // CREATE DYNAMIC TABLE must route through CreateTable (not silently
+    // become a Comment statement) and preserve TARGET_LAG / WAREHOUSE so
+    // visitors can see the referenced warehouse.
+    let sql = "CREATE OR REPLACE DYNAMIC TABLE d TARGET_LAG = '30 minutes' WAREHOUSE = wh AS SELECT a, b FROM t";
+    let stmt = snowflake().parse_sql_statements(sql).unwrap().remove(0);
+    match stmt {
+        Statement::CreateTable {
+            dynamic,
+            iceberg,
+            hybrid,
+            or_replace,
+            name,
+            query,
+            table_options,
+            ..
+        } => {
+            assert!(dynamic);
+            assert!(!iceberg);
+            assert!(!hybrid);
+            assert!(or_replace);
+            assert_eq!(name.to_string(), "d");
+            assert!(query.is_some());
+            let keys: Vec<String> = table_options
+                .iter()
+                .map(|o| o.name.to_string().to_uppercase())
+                .collect();
+            assert!(keys.iter().any(|k| k == "TARGET_LAG"), "keys={keys:?}");
+            assert!(keys.iter().any(|k| k == "WAREHOUSE"), "keys={keys:?}");
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_snowflake_create_dynamic_table_full_options() {
+    let sql = "CREATE DYNAMIC TABLE d TARGET_LAG = DOWNSTREAM WAREHOUSE = wh REFRESH_MODE = INCREMENTAL INITIALIZE = ON_CREATE AS SELECT * FROM t";
+    let stmt = snowflake().parse_sql_statements(sql).unwrap().remove(0);
+    match stmt {
+        Statement::CreateTable {
+            dynamic,
+            table_options,
+            ..
+        } => {
+            assert!(dynamic);
+            let keys: Vec<String> = table_options
+                .iter()
+                .map(|o| o.name.to_string().to_uppercase())
+                .collect();
+            for k in ["TARGET_LAG", "WAREHOUSE", "REFRESH_MODE", "INITIALIZE"] {
+                assert!(keys.iter().any(|x| x == k), "missing {k} in {keys:?}");
+            }
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_snowflake_create_hybrid_table() {
+    let sql = "CREATE HYBRID TABLE prefs (customer_id INT NOT NULL, pref_key VARCHAR(64) NOT NULL, PRIMARY KEY (customer_id, pref_key))";
+    let stmt = snowflake().parse_sql_statements(sql).unwrap().remove(0);
+    match stmt {
+        Statement::CreateTable {
+            hybrid,
+            dynamic,
+            name,
+            columns,
+            ..
+        } => {
+            assert!(hybrid);
+            assert!(!dynamic);
+            assert_eq!(name.to_string(), "prefs");
+            assert!(!columns.is_empty());
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2411,3 +2411,64 @@ fn test_snowflake_column_collate_then_default() {
         "CREATE TABLE t (c VARCHAR(32) COLLATE 'en-cs' NOT NULL DEFAULT '-' COMMENT 'd')",
     );
 }
+
+#[test]
+fn test_snowflake_create_secure_view() {
+    // Snowflake `SECURE` modifier on CREATE VIEW must set CreateView { secure: true, .. }
+    // — not fall through to a generic Comment statement (silent round-trip corruption
+    // that also hides the view from lineage visitors).
+    let cases = [
+        ("CREATE SECURE VIEW v AS SELECT id FROM t", None),
+        (
+            "CREATE OR REPLACE SECURE VIEW s.v AS SELECT id, name FROM s.t",
+            None,
+        ),
+        (
+            "CREATE OR REPLACE SECURE VIEW v COMMENT = 'desc' AS SELECT id FROM t",
+            Some("CREATE OR REPLACE SECURE VIEW v COMMENT='desc' AS SELECT id FROM t"),
+        ),
+    ];
+    for (sql, canonical) in cases {
+        let stmt = if let Some(c) = canonical {
+            snowflake().one_statement_parses_to(sql, c)
+        } else {
+            snowflake().verified_stmt(sql)
+        };
+        match stmt {
+            Statement::CreateView {
+                secure,
+                materialized,
+                name,
+                query,
+                ..
+            } => {
+                assert!(secure, "secure flag should be set for {sql}");
+                assert!(!materialized, "materialized should be false for {sql}");
+                assert!(!name.0.is_empty());
+                // Query must still hold the inner SELECT so lineage can walk it.
+                assert!(!matches!(*query, Query { .. } if false));
+                let _ = query; // silence unused
+            }
+            other => panic!("expected CreateView, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_snowflake_create_secure_materialized_view() {
+    let sql = "CREATE OR REPLACE SECURE MATERIALIZED VIEW mv AS SELECT product_id, SUM(qty) AS n FROM oi GROUP BY product_id";
+    let stmt = snowflake().verified_stmt(sql);
+    match stmt {
+        Statement::CreateView {
+            secure,
+            materialized,
+            or_replace,
+            ..
+        } => {
+            assert!(secure);
+            assert!(materialized);
+            assert!(or_replace);
+        }
+        other => panic!("expected CreateView, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Snowflake DDL with modifier keywords (`SECURE VIEW`, `SECURE MATERIALIZED VIEW`, `SECURE FUNCTION`, `DYNAMIC TABLE`, `DYNAMIC ICEBERG TABLE`, `ICEBERG TABLE`, `HYBRID TABLE`) previously fell through the generic `CREATE` fallback and returned as `Statement::Comment { object_type: Other("SECURE"|"DYNAMIC"|…), object_name: [], comment: None, … }` — silently dropping the name, columns, and query body. Visitors matching on `CreateView` / `CreateTable` / `CreateFunction` never saw these statements, and round-trip via `to_string()` was lossy.

This PR surfaces each modifier as a boolean flag on the existing AST variant:

- `Statement::CreateView { secure: bool, … }` — covers `SECURE [MATERIALIZED] VIEW`.
- `Statement::CreateFunction { secure: bool, … }` — covers `SECURE [EXTERNAL] FUNCTION`.
- `Statement::CreateTable { dynamic: bool, iceberg: bool, hybrid: bool, … }` (also on `CreateTableBuilder`) — covers `DYNAMIC [ICEBERG] TABLE`, `ICEBERG TABLE`, `HYBRID TABLE`.

Dynamic-table option keywords (`TARGET_LAG`, `WAREHOUSE`, `REFRESH_MODE`, `INITIALIZE`, `EXTERNAL_VOLUME`, `CATALOG`, `BASE_LOCATION`, `DEFAULT_DDL_COLLATION`, …) are now preserved into `table_options` as `SqlOption` entries instead of being silently discarded, so lineage can see the referenced warehouse/catalog. `REQUIRE USER`, `IMMUTABLE WHERE (…)`, and trailing `COPY GRANTS` are also accepted. `parse_column_def` now treats the next token as "no data type" when it's a column-option keyword (`COMMENT`, `TAG`, `NOT`, `NULL`, `DEFAULT`, `PRIMARY`, `UNIQUE`, `REFERENCES`, `CHECK`, `COLLATE`, `CONSTRAINT`), enabling Dynamic Table bare-column lists like `(col_a, col_b TAG (…), col_c COMMENT '…')`.

Also bundled: Redshift `CREATE PROCEDURE` accepts the `argname argmode argtype` ordering (Postgres uses `argmode argname argtype`). Both orders parse into the same `ProcedureParam`.

## Commits

- `fix(redshift)`: accept argument mode after parameter name in CREATE PROCEDURE (2 corpus fixes)
- `fix(snowflake)`: route CREATE SECURE [MATERIALIZED] VIEW through CreateView
- `fix(snowflake)`: route CREATE SECURE FUNCTION through CreateFunction
- `fix(snowflake)`: route CREATE DYNAMIC / ICEBERG / HYBRID TABLE through CreateTable

## Corpus delta

0 regressions, +6 passing files (2 Redshift procedures, 4 Postgres `COMMENT` column option). The Snowflake SECURE/DYNAMIC files counted as "passing" before only because `Comment` swallowed everything; they now parse into the correct AST variant.