### PR TITLE
feat(procedures): preserve dollar-quoted body on CreateProcedure

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2320,6 +2320,13 @@ pub enum Statement {
         name: ObjectName,
         params: Option<Vec<ProcedureParam>>,
         body: Vec<Statement>,
+        /// Raw body definition for procedures whose body is a single string
+        /// literal (typically plpgsql in `AS $$ ... $$` for
+        /// PostgreSQL/Redshift). When set, `body` is empty because the
+        /// contents are opaque to the SQL parser; downstream consumers such
+        /// as kernel-cll re-parse the string leniently to extract embedded
+        /// DML/DDL for lineage purposes.
+        body_definition: Option<FunctionDefinition>,
     },
     /// ```sql
     /// CREATE MACRO
@@ -3045,6 +3052,7 @@ impl fmt::Display for Statement {
                 or_alter,
                 params,
                 body,
+                body_definition,
             } => {
                 write!(
                     f,
@@ -3058,11 +3066,15 @@ impl fmt::Display for Statement {
                         write!(f, " ({})", display_comma_separated(p))?;
                     }
                 }
-                write!(
-                    f,
-                    " AS BEGIN {body} END",
-                    body = display_separated(body, "; ")
-                )
+                if let Some(def) = body_definition {
+                    write!(f, " AS {def}")
+                } else {
+                    write!(
+                        f,
+                        " AS BEGIN {body} END",
+                        body = display_separated(body, "; ")
+                    )
+                }
             }
             Statement::CreateMacro {
                 or_replace,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14831,6 +14831,7 @@ impl<'a> Parser<'a> {
                 or_alter,
                 params,
                 body: vec![],
+                body_definition: None,
             });
         }
 
@@ -14843,10 +14844,27 @@ impl<'a> Parser<'a> {
                 or_alter,
                 params,
                 body: statements,
+                body_definition: None,
             })
         } else {
-            // Body is a string literal or expression - skip to end of statement
-            let _ = self.parse_expr();
+            // Body is a string literal (plpgsql in `AS $$...$$` or `AS '...'`)
+            // or another expression. Capture the raw definition string so
+            // downstream consumers (lineage extractors) can re-parse it, then
+            // skip the remainder of the statement.
+            let body_definition = match self.peek_token().token.clone() {
+                Token::DollarQuotedString(s) => {
+                    self.next_token();
+                    Some(FunctionDefinition::DoubleDollarDef(s.value))
+                }
+                Token::SingleQuotedString(s) => {
+                    self.next_token();
+                    Some(FunctionDefinition::SingleQuotedDef(s))
+                }
+                _ => {
+                    let _ = self.parse_expr();
+                    None
+                }
+            };
             // Consume trailing clauses like `LANGUAGE plpgsql`, `SECURITY INVOKER`,
             // `STABLE`, `VOLATILE`, etc. that follow the body in PostgreSQL/Redshift.
             loop {
@@ -14862,6 +14880,7 @@ impl<'a> Parser<'a> {
                 or_alter,
                 params,
                 body: vec![],
+                body_definition,
             })
         }
     }

--- a/tests/redshift_customer_procedure_samples.rs
+++ b/tests/redshift_customer_procedure_samples.rs
@@ -5,12 +5,62 @@
 //! refcursors, RAISE EXCEPTION — are preserved so that regressions in
 //! how we tokenize or parse these constructs will fail loudly.
 
+use sqlparser::ast::{FunctionDefinition, Statement};
 use sqlparser::dialect::RedshiftSqlDialect;
 use sqlparser::parser::Parser;
 
 fn assert_parses(sql: &str) {
     Parser::parse_sql(&RedshiftSqlDialect {}, sql)
         .unwrap_or_else(|e| panic!("parse failed: {e}\nSQL:\n{sql}"));
+}
+
+#[test]
+fn redshift_plpgsql_procedure_preserves_body_definition() {
+    // The parser cannot walk plpgsql, but it must preserve the raw dollar-
+    // quoted body string in `CreateProcedure.body_definition` so downstream
+    // consumers (lineage extractors) can re-parse it.
+    let sql = r#"CREATE OR REPLACE PROCEDURE analytics.load_daily()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO analytics.daily SELECT * FROM staging.daily;
+END;
+$$;"#;
+    let mut stmts = Parser::parse_sql(&RedshiftSqlDialect {}, sql).unwrap();
+    assert_eq!(stmts.len(), 1);
+    match stmts.pop().unwrap() {
+        Statement::CreateProcedure {
+            body,
+            body_definition,
+            ..
+        } => {
+            assert!(body.is_empty(), "plpgsql body is opaque, body should be empty");
+            let def = body_definition.expect("body_definition should carry the $$..$$ string");
+            let raw = match def {
+                FunctionDefinition::DoubleDollarDef(s) => s,
+                other => panic!("expected DoubleDollarDef, got {other:?}"),
+            };
+            assert!(raw.contains("INSERT INTO analytics.daily"));
+            assert!(raw.contains("FROM staging.daily"));
+        }
+        other => panic!("expected CreateProcedure, got {other:?}"),
+    }
+}
+
+#[test]
+fn redshift_plpgsql_procedure_single_quoted_body_preserved() {
+    // Single-quoted body variant — rarer but legal in PostgreSQL/Redshift.
+    let sql = "CREATE OR REPLACE PROCEDURE analytics.noop() LANGUAGE plpgsql AS 'BEGIN NULL; END;';";
+    let mut stmts = Parser::parse_sql(&RedshiftSqlDialect {}, sql).unwrap();
+    match stmts.pop().unwrap() {
+        Statement::CreateProcedure {
+            body_definition: Some(FunctionDefinition::SingleQuotedDef(s)),
+            ..
+        } => {
+            assert!(s.contains("BEGIN"));
+        }
+        other => panic!("expected CreateProcedure with SingleQuotedDef, got {other:?}"),
+    }
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -90,6 +90,7 @@ fn parse_create_procedure() {
         ms().verified_stmt(sql),
         Statement::CreateProcedure {
             or_alter: true,
+            body_definition: None,
             body: vec![Statement::Query(Box::new(Query {
                 with: None,
                 limit: None,


### PR DESCRIPTION
## Summary
- Add `body_definition: Option<FunctionDefinition>` to `Statement::CreateProcedure` so PostgreSQL/Redshift plpgsql bodies (`AS \$\$ ... \$\$` / `AS '...'`) survive parsing.
- Previously the parser consumed the body expression and dropped it; consumers that need the procedure source (lineage extractors, re-writers) had no recovery path.
- `BEGIN/END` bodies are unchanged: `body` stays populated, `body_definition` is `None`.