### PR TITLE
sqlparser-rs: record body_start Location on FunctionDefinition

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -62,7 +62,7 @@ pub use self::value::{
 use crate::ast::helpers::stmt_data_loading::{
     DataLoadingOptions, StageLoadSelectItem, StageParamsObject,
 };
-use crate::tokenizer::Span;
+use crate::tokenizer::{Location, Span};
 #[cfg(feature = "visitor")]
 pub use visitor::*;
 
@@ -5920,21 +5920,122 @@ impl fmt::Display for FunctionBehavior {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum FunctionDefinition {
-    SingleQuotedDef(String),
-    DoubleDollarDef(String),
+    /// `AS '...'` — single-quoted routine body.
+    ///
+    /// `body_start` is the location (1-based line + column) of the first
+    /// character of `value` in the outer SQL source — i.e. the character
+    /// immediately after the opening `'`. Consumers that re-parse routine
+    /// bodies (e.g. plpgsql lineage extraction) use this to remap
+    /// body-relative token spans back to the outer SQL.
+    ///
+    /// When the body is synthesized (e.g. ClickHouse `AS (expr) -> ...`
+    /// re-serialises the parsed expression) `body_start` falls back to
+    /// `Location::default()` (line 0), which [`Location::is_valid`]
+    /// reports as invalid.
+    SingleQuotedDef {
+        value: String,
+        body_start: Location,
+    },
+    /// `AS $$...$$` (or tagged `$tag$...$tag$`) — dollar-quoted routine body.
+    ///
+    /// `body_start` is the location of the first character of `value`,
+    /// i.e. the character immediately after the opening `$$` / `$tag$`.
+    DoubleDollarDef {
+        value: String,
+        body_start: Location,
+    },
+}
+
+impl FunctionDefinition {
+    /// Raw body text, without surrounding quotes / dollar-tags.
+    pub fn value(&self) -> &str {
+        match self {
+            FunctionDefinition::SingleQuotedDef { value, .. }
+            | FunctionDefinition::DoubleDollarDef { value, .. } => value,
+        }
+    }
+
+    /// Location of the first character of the body in the outer SQL.
+    /// Returns `Location::default()` (invalid) when not known — e.g. when
+    /// the body was synthesized from a parsed AST rather than copied
+    /// verbatim from the source.
+    pub fn body_start(&self) -> Location {
+        match self {
+            FunctionDefinition::SingleQuotedDef { body_start, .. }
+            | FunctionDefinition::DoubleDollarDef { body_start, .. } => *body_start,
+        }
+    }
 }
 
 impl fmt::Display for FunctionDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            FunctionDefinition::SingleQuotedDef(s) => write!(f, "'{s}'")?,
-            FunctionDefinition::DoubleDollarDef(s) => write!(f, "$${s}$$")?,
+            FunctionDefinition::SingleQuotedDef { value, .. } => write!(f, "'{value}'")?,
+            FunctionDefinition::DoubleDollarDef { value, .. } => write!(f, "$${value}$$")?,
         }
         Ok(())
+    }
+}
+
+// Custom equality / ordering / hashing: `body_start` is a *source
+// position*, not semantic information, so two ASTs that differ only in
+// where the body physically sat in their respective source strings must
+// still be considered equal. This matters most for round-trip tests
+// that parse → Display → re-parse (the canonical form starts the body
+// at a different column than the original).
+#[allow(clippy::derived_hash_with_manual_eq)]
+impl PartialEq for FunctionDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                FunctionDefinition::SingleQuotedDef { value: a, .. },
+                FunctionDefinition::SingleQuotedDef { value: b, .. },
+            ) => a == b,
+            (
+                FunctionDefinition::DoubleDollarDef { value: a, .. },
+                FunctionDefinition::DoubleDollarDef { value: b, .. },
+            ) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for FunctionDefinition {}
+
+impl PartialOrd for FunctionDefinition {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FunctionDefinition {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        fn key(d: &FunctionDefinition) -> (u8, &str) {
+            match d {
+                FunctionDefinition::SingleQuotedDef { value, .. } => (0, value.as_str()),
+                FunctionDefinition::DoubleDollarDef { value, .. } => (1, value.as_str()),
+            }
+        }
+        key(self).cmp(&key(other))
+    }
+}
+
+impl core::hash::Hash for FunctionDefinition {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            FunctionDefinition::SingleQuotedDef { value, .. } => {
+                0u8.hash(state);
+                value.hash(state);
+            }
+            FunctionDefinition::DoubleDollarDef { value, .. } => {
+                1u8.hash(state);
+                value.hash(state);
+            }
+        }
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -97,6 +97,45 @@ impl ParserErrorMessage {
     }
 }
 
+/// Returns the source `Location` of the first body character inside a
+/// dollar-quoted string. Given the token's starting `Location` (the `$` of
+/// the opening `$[tag]$`) and the token's parsed tag, the body follows the
+/// opening tag on the same line.
+///
+/// The opening delimiter is `$$` (tag absent) or `$tag$` (tag present); its
+/// length is therefore `tag.len() + 2` code points on the starting line.
+fn dollar_quoted_body_start(
+    open_start: Location,
+    dollar: &crate::ast::DollarQuotedString,
+) -> Location {
+    let tag_len = dollar.tag.as_deref().map(str::len).unwrap_or(0) as u64;
+    Location {
+        line: open_start.line,
+        column: open_start.column.saturating_add(tag_len + 2),
+    }
+}
+
+/// Returns the source `Location` of the first body character for a
+/// single-quoted / double-quoted string literal (or a bare identifier used
+/// as a literal). For quoted strings the body starts one column after the
+/// opening quote; for an un-quoted identifier the body *is* the token, so
+/// `body_start == peek.span.start`.
+fn literal_string_body_start(peek: &TokenWithLocation) -> Location {
+    let start = peek.span.start;
+    let offset: u64 = match &peek.token {
+        Token::SingleQuotedString(_)
+        | Token::DoubleQuotedString(_)
+        | Token::EscapedStringLiteral(_)
+        | Token::NationalStringLiteral(_)
+        | Token::HexStringLiteral(_) => 1,
+        _ => 0,
+    };
+    Location {
+        line: start.line,
+        column: start.column.saturating_add(offset),
+    }
+}
+
 fn env_flag_enabled(name: &'static str) -> bool {
     match std::env::var(name) {
         Ok(v) => !v.is_empty() && v != "0",
@@ -4740,8 +4779,13 @@ impl<'a> Parser<'a> {
             let name = self.parse_object_name(false)?;
             self.expect_keyword(Keyword::AS)?;
             let expr = self.parse_expr()?;
+            // ClickHouse synthesises the "body" from a parsed expression, so we
+            // don't have a source-faithful starting location for it.
             let params = CreateFunctionBody {
-                as_: Some(FunctionDefinition::SingleQuotedDef(expr.to_string())),
+                as_: Some(FunctionDefinition::SingleQuotedDef {
+                    value: expr.to_string(),
+                    body_start: Location::default(),
+                }),
                 ..Default::default()
             };
             Ok(Statement::CreateFunction {
@@ -8852,20 +8896,32 @@ impl<'a> Parser<'a> {
     pub fn parse_function_definition(&mut self) -> Result<FunctionDefinition, ParserError> {
         let peek_token = self.peek_token();
         match peek_token.token {
-            Token::DollarQuotedString(value) => {
+            Token::DollarQuotedString(ref value) => {
+                let body_start = dollar_quoted_body_start(peek_token.span.start, value);
                 self.next_token();
-                Ok(FunctionDefinition::DoubleDollarDef(value.value))
+                Ok(FunctionDefinition::DoubleDollarDef {
+                    value: value.value.clone(),
+                    body_start,
+                })
             }
             Token::LParen => {
-                // BigQuery/Snowflake: AS (expr)
+                // BigQuery/Snowflake: AS (expr) — synthesized body, no
+                // source-faithful start location.
                 self.expect_token(&Token::LParen)?;
                 let expr = self.parse_expr()?;
                 self.expect_token(&Token::RParen)?;
-                Ok(FunctionDefinition::SingleQuotedDef(expr.to_string()))
+                Ok(FunctionDefinition::SingleQuotedDef {
+                    value: expr.to_string(),
+                    body_start: Location::default(),
+                })
             }
-            _ => Ok(FunctionDefinition::SingleQuotedDef(
-                self.parse_literal_string()?,
-            )),
+            _ => {
+                let body_start = literal_string_body_start(&peek_token);
+                Ok(FunctionDefinition::SingleQuotedDef {
+                    value: self.parse_literal_string()?,
+                    body_start,
+                })
+            }
         }
     }
     /// Parse a literal string
@@ -14851,18 +14907,33 @@ impl<'a> Parser<'a> {
             // or another expression. Capture the raw definition string so
             // downstream consumers (lineage extractors) can re-parse it, then
             // skip the remainder of the statement.
-            let body_definition = match self.peek_token().token.clone() {
-                Token::DollarQuotedString(s) => {
-                    self.next_token();
-                    Some(FunctionDefinition::DoubleDollarDef(s.value))
-                }
-                Token::SingleQuotedString(s) => {
-                    self.next_token();
-                    Some(FunctionDefinition::SingleQuotedDef(s))
-                }
-                _ => {
-                    let _ = self.parse_expr();
-                    None
+            let body_definition = {
+                let peek = self.peek_token();
+                match peek.token.clone() {
+                    Token::DollarQuotedString(s) => {
+                        let body_start = dollar_quoted_body_start(peek.span.start, &s);
+                        self.next_token();
+                        Some(FunctionDefinition::DoubleDollarDef {
+                            value: s.value,
+                            body_start,
+                        })
+                    }
+                    Token::SingleQuotedString(s) => {
+                        // Opening `'` sits at peek.span.start; body follows it.
+                        let body_start = Location {
+                            line: peek.span.start.line,
+                            column: peek.span.start.column.saturating_add(1),
+                        };
+                        self.next_token();
+                        Some(FunctionDefinition::SingleQuotedDef {
+                            value: s,
+                            body_start,
+                        })
+                    }
+                    _ => {
+                        let _ = self.parse_expr();
+                        None
+                    }
                 }
             };
             // Consume trailing clauses like `LANGUAGE plpgsql`, `SECURITY INVOKER`,

--- a/tests/redshift_customer_procedure_samples.rs
+++ b/tests/redshift_customer_procedure_samples.rs
@@ -8,6 +8,22 @@
 use sqlparser::ast::{FunctionDefinition, Statement};
 use sqlparser::dialect::RedshiftSqlDialect;
 use sqlparser::parser::Parser;
+use sqlparser::tokenizer::{Location, Tokenizer};
+
+/// Parse preserving token spans — [`Parser::parse_sql`] strips locations
+/// via [`Tokenizer::tokenize`] for backwards compatibility, which zeros out
+/// every `Span`. Tests that assert on source positions must feed the parser
+/// via `tokenize_with_location` + `with_tokens_with_locations`.
+fn parse_sql_with_locations(sql: &str) -> Vec<Statement> {
+    let dialect = RedshiftSqlDialect {};
+    let tokens = Tokenizer::new(&dialect, sql)
+        .tokenize_with_location()
+        .unwrap();
+    Parser::new(&dialect)
+        .with_tokens_with_locations(tokens)
+        .parse_statements()
+        .unwrap()
+}
 
 fn assert_parses(sql: &str) {
     Parser::parse_sql(&RedshiftSqlDialect {}, sql)
@@ -37,7 +53,7 @@ $$;"#;
             assert!(body.is_empty(), "plpgsql body is opaque, body should be empty");
             let def = body_definition.expect("body_definition should carry the $$..$$ string");
             let raw = match def {
-                FunctionDefinition::DoubleDollarDef(s) => s,
+                FunctionDefinition::DoubleDollarDef { value, .. } => value,
                 other => panic!("expected DoubleDollarDef, got {other:?}"),
             };
             assert!(raw.contains("INSERT INTO analytics.daily"));
@@ -48,16 +64,95 @@ $$;"#;
 }
 
 #[test]
+fn function_definition_records_body_start_for_dollar_quoted_body() {
+    // Body starts at the first character after the opening `$$`. For
+    //   line 3:  `AS $$\n`
+    //   line 4:  `BEGIN\n`
+    // the opening `$$` begins at column 4 on line 3, so `body_start` must
+    // point at line 3, column 6 (the newline immediately after `$$`).
+    let sql = "CREATE OR REPLACE PROCEDURE analytics.load()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NULL;
+END;
+$$;";
+    let mut stmts = parse_sql_with_locations(sql);
+    let def = match stmts.pop().unwrap() {
+        Statement::CreateProcedure {
+            body_definition: Some(def),
+            ..
+        } => def,
+        other => panic!("expected CreateProcedure with body_definition, got {other:?}"),
+    };
+    match def {
+        FunctionDefinition::DoubleDollarDef { value, body_start } => {
+            assert!(value.contains("BEGIN"));
+            assert_eq!(
+                body_start,
+                Location { line: 3, column: 6 },
+                "body_start should point at the first character after `AS $$`"
+            );
+        }
+        other => panic!("expected DoubleDollarDef, got {other:?}"),
+    }
+}
+
+#[test]
+fn function_definition_records_body_start_for_tagged_dollar_body() {
+    // `$tag$` opening is `tag.len() + 2` chars wide. For `AS $body$...$body$;`
+    // on line 1, the `$body$` opening starts at column 16 (the `$`), so the
+    // body's first character is at column 16 + len("body") + 2 = 22.
+    let sql = "CREATE FUNCTION f() RETURNS int LANGUAGE plpgsql AS $body$ BEGIN RETURN 1; END; $body$;";
+    let mut stmts = parse_sql_with_locations(sql);
+    let def = match stmts.pop().unwrap() {
+        Statement::CreateFunction { params, .. } => params.as_.expect("as_ must be set"),
+        other => panic!("expected CreateFunction, got {other:?}"),
+    };
+    match def {
+        FunctionDefinition::DoubleDollarDef { body_start, .. } => {
+            // Column of the opening `$` of `$body$` = 54 (1-based). Opening
+            // delimiter length = 6. body_start column = 54 + 6 = 60.
+            let open_col = sql.find("$body$").unwrap() as u64 + 1;
+            let expected_col = open_col + ("body".len() as u64) + 2;
+            assert_eq!(body_start, Location { line: 1, column: expected_col });
+        }
+        other => panic!("expected DoubleDollarDef, got {other:?}"),
+    }
+}
+
+#[test]
+fn function_definition_records_body_start_for_single_quoted_body() {
+    // Opening `'` at column 70; body starts at column 71.
+    let sql = "CREATE OR REPLACE PROCEDURE analytics.noop() LANGUAGE plpgsql AS 'BEGIN NULL; END;';";
+    let mut stmts = parse_sql_with_locations(sql);
+    let def = match stmts.pop().unwrap() {
+        Statement::CreateProcedure {
+            body_definition: Some(def),
+            ..
+        } => def,
+        other => panic!("expected CreateProcedure with body_definition, got {other:?}"),
+    };
+    match def {
+        FunctionDefinition::SingleQuotedDef { body_start, .. } => {
+            let open_col = sql.find('\'').unwrap() as u64 + 1;
+            assert_eq!(body_start, Location { line: 1, column: open_col + 1 });
+        }
+        other => panic!("expected SingleQuotedDef, got {other:?}"),
+    }
+}
+
+#[test]
 fn redshift_plpgsql_procedure_single_quoted_body_preserved() {
     // Single-quoted body variant — rarer but legal in PostgreSQL/Redshift.
     let sql = "CREATE OR REPLACE PROCEDURE analytics.noop() LANGUAGE plpgsql AS 'BEGIN NULL; END;';";
     let mut stmts = Parser::parse_sql(&RedshiftSqlDialect {}, sql).unwrap();
     match stmts.pop().unwrap() {
         Statement::CreateProcedure {
-            body_definition: Some(FunctionDefinition::SingleQuotedDef(s)),
+            body_definition: Some(FunctionDefinition::SingleQuotedDef { value, .. }),
             ..
         } => {
-            assert!(s.contains("BEGIN"));
+            assert!(value.contains("BEGIN"));
         }
         other => panic!("expected CreateProcedure with SingleQuotedDef, got {other:?}"),
     }

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -256,9 +256,11 @@ fn parse_create_function() {
             assert_eq!(
                 params,
                 CreateFunctionBody {
-                    as_: Some(FunctionDefinition::SingleQuotedDef(
-                        "org.random.class.Name".to_string()
-                    )),
+                    as_: Some(FunctionDefinition::SingleQuotedDef {
+                        value: "org.random.class.Name".to_string(),
+                        // Ignored by PartialEq; any value works.
+                        body_start: Default::default(),
+                    }),
                     using: Some(CreateFunctionUsing::Jar(
                         "hdfs://somewhere.com:8020/very/far".to_string()
                     )),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3549,9 +3549,10 @@ fn parse_create_function() {
             params: CreateFunctionBody {
                 language: Some("SQL".into()),
                 behavior: Some(FunctionBehavior::Immutable),
-                as_: Some(FunctionDefinition::SingleQuotedDef(
-                    "select $1 + $2;".into()
-                )),
+                as_: Some(FunctionDefinition::SingleQuotedDef {
+                    value: "select $1 + $2;".into(),
+                    body_start: Default::default(),
+                }),
                 ..Default::default()
             },
             secure: false,
@@ -3610,9 +3611,10 @@ fn parse_create_function() {
                 behavior: None,
                 return_: None,
                 return_select_: None,
-                as_: Some(FunctionDefinition::DoubleDollarDef(
-                    " BEGIN RETURN i + 1; END; ".into()
-                )),
+                as_: Some(FunctionDefinition::DoubleDollarDef {
+                    value: " BEGIN RETURN i + 1; END; ".into(),
+                    body_start: Default::default(),
+                }),
                 as_query: None,
                 using: None,
                 strict: false,


### PR DESCRIPTION
## Summary
- `FunctionDefinition::{SingleQuotedDef, DoubleDollarDef}` now carry `body_start: Location` — the (line, column) of the first body character in the outer SQL, i.e. immediately after the opening `'` / `$$` / `$tag$`. This lets consumers that re-tokenize routine bodies (plpgsql column lineage in kernel-cll) remap body-relative token spans back into outer-SQL coordinates; today the body tokenizer starts at (1,1), so every collected span points at the wrong slice of the global SQL.
- Variants moved from tuple to struct form with `value()` / `body_start()` accessors. `PartialEq`/`Eq`/`Ord`/`Hash` are hand-written to ignore `body_start` so round-trip tests (parse → Display → re-parse) still compare equal. `Debug`/`Clone`/serde/visitor derives retained.
- Three regression tests in `redshift_customer_procedure_samples` pin `body_start` for the dollar-quoted, tagged-dollar (`\$tag\$...\$tag\$`), and single-quoted body shapes, using a local `tokenize_with_location` + `with_tokens_with_locations` helper (`Parser::parse_sql` intentionally still strips spans for backcompat).

## Notes
- Stacked on #66 — that PR introduces the `body_definition` field I'm populating with source positions here. Base is `lukasz-create-procedure-body-definition`; please land #66 first and I'll retarget this to `main`.
- ClickHouse `AS (expr) -> ...` synthesises the body from a parsed expression rather than quoting a literal, so it falls back to `Location::default()`.
- Full test run green: `cargo nextest run --all-features` → 995 passed, 2 skipped.