### PR TITLE
Five parser gaps blocking ~1.5k SQL definitions

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1969,7 +1969,12 @@ impl<'a> Parser<'a> {
     pub fn parse_extract_expr(&mut self) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LParen)?;
         let field = self.parse_date_time_field()?;
-        self.expect_keyword(Keyword::FROM)?;
+        // Standard form is `EXTRACT(<part> FROM <expr>)`; Snowflake also
+        // supports the comma form `EXTRACT(<part>, <expr>)`.
+        // https://docs.snowflake.com/en/sql-reference/functions/extract
+        if !self.consume_token(&Token::Comma) {
+            self.expect_keyword(Keyword::FROM)?;
+        }
         let expr = self.parse_expr()?;
         self.expect_token(&Token::RParen)?;
         Ok(Expr::Extract {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15304,6 +15304,13 @@ impl<'a> Parser<'a> {
             None
         };
 
+        // Inside PARTITION BY / ORDER BY of a window spec, the surrounding `)`
+        // already delimits the list. Disable trailing-comma "clause keyword"
+        // termination so that columns named after reserved keywords (e.g.
+        // BigQuery's `WITH OFFSET AS offset` alias) don't trip
+        // `is_parse_comma_separated_end`.
+        let old_trailing = self.options.trailing_commas;
+        self.options.trailing_commas = false;
         let partition_by = if self.parse_keywords(&[Keyword::PARTITION, Keyword::BY]) {
             self.parse_comma_separated(Parser::parse_expr)?
         } else {
@@ -15314,6 +15321,7 @@ impl<'a> Parser<'a> {
         } else {
             vec![]
         };
+        self.options.trailing_commas = old_trailing;
         let window_frame = if !self.consume_token(&Token::RParen) {
             let window_frame = self.parse_window_frame()?;
             self.expect_token(&Token::RParen)?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7157,8 +7157,14 @@ impl<'a> Parser<'a> {
             None
         };
 
-        // Skip optional TAG (...) clause on columns (Snowflake)
-        self.parse_optional_tag_clause();
+        // Skip optional [WITH] TAG (...) clause on columns (Snowflake)
+        if self.parse_keyword(Keyword::WITH) {
+            if !self.parse_optional_tag_clause() {
+                self.prev_token();
+            }
+        } else {
+            self.parse_optional_tag_clause();
+        }
 
         // COMMENT may appear after MASKING POLICY / TAG (Snowflake)
         if self.parse_keyword(Keyword::COMMENT) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9561,6 +9561,19 @@ impl<'a> Parser<'a> {
             Token::Word(w) if after_as || !reserved_kwds.contains(&w.keyword) => {
                 Ok(Some(w.to_ident().spanning(next_token.span)))
             }
+            // CLUSTER is reserved only because of `CLUSTER BY` (Hive/Spark
+            // SELECT-level clause and Snowflake/BigQuery DDL clause). When the
+            // following token is not BY, the keyword is being used as a regular
+            // identifier alias — e.g. BigQuery `JOIN tbl cluster ON ...`.
+            Token::Word(w)
+                if w.keyword == Keyword::CLUSTER
+                    && !matches!(
+                        self.peek_token_kind(),
+                        Token::Word(next) if next.keyword == Keyword::BY,
+                    ) =>
+            {
+                Ok(Some(w.to_ident().spanning(next_token.span)))
+            }
             // MSSQL supports single-quoted strings as aliases for columns
             // We accept them as table aliases too, although MSSQL does not.
             //

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5278,10 +5278,13 @@ impl<'a> Parser<'a> {
             Keyword::POLICY,
         ]) {
             let _ = self.parse_object_name(false)?;
-            self.expect_keyword(Keyword::ON)?;
-            self.expect_token(&Token::LParen)?;
-            let _ = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-            self.expect_token(&Token::RParen)?;
+            // ON (cols) is optional — Snowflake's GET_DDL omits it when the caller
+            // lacks privilege to see the policy.
+            if self.parse_keyword(Keyword::ON) {
+                self.expect_token(&Token::LParen)?;
+                let _ = self.parse_comma_separated(|p| p.parse_identifier(false))?;
+                self.expect_token(&Token::RParen)?;
+            }
         }
 
         let with_options = self.parse_options(Keyword::WITH)?;
@@ -6441,20 +6444,24 @@ impl<'a> Parser<'a> {
             // https://docs.snowflake.com/en/sql-reference/sql/create-table
             if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
                 let _policy = self.parse_object_name(false)?;
-                self.expect_keyword(Keyword::ON)?;
-                self.expect_token(&Token::LParen)?;
-                let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-                self.expect_token(&Token::RParen)?;
+                // ON (cols) is optional — Snowflake's GET_DDL omits it when the caller
+                // lacks privilege to see the policy ("WITH ROW ACCESS POLICY unknown_policy").
+                if self.parse_keyword(Keyword::ON) {
+                    self.expect_token(&Token::LParen)?;
+                    let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
+                    self.expect_token(&Token::RParen)?;
+                }
                 continue;
             }
             {
                 let with = self.parse_keyword(Keyword::WITH);
                 if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
                     let _policy = self.parse_object_name(false)?;
-                    self.expect_keyword(Keyword::ON)?;
-                    self.expect_token(&Token::LParen)?;
-                    let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-                    self.expect_token(&Token::RParen)?;
+                    if self.parse_keyword(Keyword::ON) {
+                        self.expect_token(&Token::LParen)?;
+                        let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
+                        self.expect_token(&Token::RParen)?;
+                    }
                     continue;
                 } else if with && self.parse_optional_tag_clause() {
                     continue;

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1986,6 +1986,25 @@ fn test_bigquery_window_named_ref() {
 }
 
 #[test]
+fn test_bigquery_cluster_as_identifier() {
+    // CLUSTER is reserved only because of `CLUSTER BY` (Hive/Spark SELECT
+    // clause and BigQuery DDL). When the next token isn't BY it should parse
+    // as a regular alias — real-world: customers name JOIN aliases / columns
+    // `cluster`.
+    bigquery().one_statement_parses_to(
+        "SELECT * FROM t LEFT JOIN budgets cluster ON budgets.x = cluster.y",
+        "SELECT * FROM t LEFT JOIN budgets AS cluster ON budgets.x = cluster.y",
+    );
+    bigquery().verified_stmt("SELECT cluster.x AS cluster FROM (SELECT 1 AS x) AS cluster");
+    // CLUSTER BY in Hive/Spark must still be recognized as the keyword.
+    sqlparser::test_utils::TestedDialects {
+        dialects: vec![Box::new(sqlparser::dialect::HiveDialect {})],
+        options: None,
+    }
+    .verified_stmt("SELECT * FROM t CLUSTER BY x");
+}
+
+#[test]
 fn test_bigquery_window_order_by_offset_alias() {
     // BigQuery's `UNNEST(arr) WITH OFFSET AS offset` introduces a column named
     // `offset` (overlapping the OFFSET keyword). The window spec's ORDER BY

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1986,6 +1986,20 @@ fn test_bigquery_window_named_ref() {
 }
 
 #[test]
+fn test_bigquery_window_order_by_offset_alias() {
+    // BigQuery's `UNNEST(arr) WITH OFFSET AS offset` introduces a column named
+    // `offset` (overlapping the OFFSET keyword). The window spec's ORDER BY
+    // must accept it as a regular identifier — previously the trailing-comma
+    // logic left over from BigQuery projections treated `, offset` as a
+    // trailing-comma terminator and looked for a window frame instead.
+    bigquery().verified_stmt(
+        "SELECT ROW_NUMBER() OVER (PARTITION BY ticket_id ORDER BY version_index, offset ASC) AS version_index FROM t",
+    );
+    // Same alias used in PARTITION BY.
+    bigquery().verified_stmt("SELECT SUM(x) OVER (PARTITION BY id, offset ORDER BY x) FROM t");
+}
+
+#[test]
 fn parse_bigquery_full_union_by_name() {
     // FULL UNION ALL BY NAME - BigQuery set operation matching columns by name with outer-join semantics
     bigquery().verified_query("SELECT * FROM t1 FULL UNION ALL BY NAME SELECT * FROM t2");

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1648,6 +1648,18 @@ fn parse_extract_custom_part() {
 }
 
 #[test]
+fn parse_extract_comma_form() {
+    // Snowflake also accepts the comma form `EXTRACT(<part>, <expr>)` as a
+    // shorthand for the standard `EXTRACT(<part> FROM <expr>)`.
+    // https://docs.snowflake.com/en/sql-reference/functions/extract
+    let select = snowflake().one_statement_parses_to(
+        "SELECT extract(year, birthdate) AS year_of_birth FROM t",
+        "SELECT EXTRACT(YEAR FROM birthdate) AS year_of_birth FROM t",
+    );
+    assert!(matches!(select, Statement::Query(_)));
+}
+
+#[test]
 fn parse_create_table_comment() {
     snowflake().verified_stmt("CREATE TABLE my_table (my_column STRING COMMENT 'column comment')");
     snowflake().one_statement_parses_to(

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2089,6 +2089,20 @@ fn parse_create_table_with_row_access_policy() {
         "CREATE TABLE t1 (id VARCHAR) WITH TAG (k = 'v') WITH ROW ACCESS POLICY p1 ON (id)",
         "CREATE TABLE t1 (id VARCHAR)",
     );
+    // Snowflake's GET_DDL omits `ON (cols)` when the caller lacks privilege to
+    // see the policy — it returns `WITH ROW ACCESS POLICY unknown_policy` only.
+    snowflake().one_statement_parses_to(
+        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY unknown_policy",
+        "CREATE TABLE t1 (id VARCHAR)",
+    );
+    snowflake().one_statement_parses_to(
+        "CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY unknown_policy",
+        "CREATE TABLE t1 (id VARCHAR)",
+    );
+    snowflake().one_statement_parses_to(
+        "CREATE VIEW v1 WITH ROW ACCESS POLICY unknown_policy AS SELECT * FROM t1",
+        "CREATE VIEW v1 AS SELECT * FROM t1",
+    );
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1852,6 +1852,26 @@ fn test_table_with_tag() {
 }
 
 #[test]
+fn test_column_with_tag() {
+    // Column-level WITH TAG (...) — Snowflake docs allow `[ WITH ] TAG (...)` on columns,
+    // same shape as the table-level form.
+    snowflake().one_statement_parses_to(
+        "CREATE TABLE t (col NUMBER(18, 4) WITH TAG (a.b.c = 'True'))",
+        "CREATE TABLE t (col NUMBER(18, 4))",
+    );
+    // Multiple columns, mixed with regular options.
+    snowflake().one_statement_parses_to(
+        "CREATE TABLE t (id INT, amt NUMBER(18, 4) WITH TAG (schema.tag = 'val'), name VARCHAR)",
+        "CREATE TABLE t (id INT, amt NUMBER(18, 4), name VARCHAR)",
+    );
+    // Bare TAG (no WITH) still works (existing behavior).
+    snowflake().one_statement_parses_to(
+        "CREATE TABLE t (col NUMBER(18, 4) TAG (a.b = 'v'))",
+        "CREATE TABLE t (col NUMBER(18, 4))",
+    );
+}
+
+#[test]
 fn test_describe_table() {
     snowflake().verified_stmt(r#"DESCRIBE TABLE "DW_PROD"."SCH"."TBL""#);
 }


### PR DESCRIPTION
## Summary

Five parser fixes addressing the residual `parseFailed=true` SqlDefinitions surfaced by PR-7179, after the procedure/function-body rollout had cleared the routine-body population.

- `fix(snowflake)`: support column-level `WITH TAG (...)` in `CREATE TABLE` (~458 defs).
- `fix(snowflake)`: allow `WITH ROW ACCESS POLICY <name>` without `ON (cols)` — Snowflake's `GET_DDL` emits this when the caller lacks privilege to see the policy (~253 defs).
- `fix(bigquery)`: allow `OFFSET` as identifier inside window `ORDER BY`/`PARTITION BY` — `UNNEST(arr) WITH OFFSET AS offset` introduces a column overlapping the keyword (~40 defs).
- `fix`: accept `CLUSTER` as identifier when not followed by `BY` — Hive's `CLUSTER BY` clause is the only reason CLUSTER was reserved as an alias (~17 defs).
- `fix(snowflake)`: accept `EXTRACT(<part>, <expr>)` comma form (~10 defs).

Each fix is committed independently with regression tests in the matching `tests/sqlparser_<dialect>.rs` file. No corpus regressions; corpus delta is small because the reproductions live in production SqlDefinitions, not the kernel-cll-corpus snapshot.

## References

- Linear: PR-7179
- Playbook: `playbooks/CLL.md` (rollout pattern after merge + submodule bump in `cloud`)