### PR TITLE
fix(postgres,redshift): accept ~~ / ~~* / !~~ / !~~* LIKE/ILIKE operators

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -139,6 +139,14 @@ pub enum BinaryOperator {
     PGRegexNotMatch,
     /// String does not match regular expression (case insensitively), e.g. `a !~* b` (PostgreSQL-specific)
     PGRegexNotIMatch,
+    /// String LIKE match, e.g. `a ~~ b` — operator alias for `LIKE` (PostgreSQL/Redshift-specific)
+    PGLikeMatch,
+    /// String ILIKE match, e.g. `a ~~* b` — operator alias for `ILIKE` (PostgreSQL/Redshift-specific)
+    PGILikeMatch,
+    /// String NOT LIKE match, e.g. `a !~~ b` — operator alias for `NOT LIKE` (PostgreSQL/Redshift-specific)
+    PGNotLikeMatch,
+    /// String NOT ILIKE match, e.g. `a !~~* b` — operator alias for `NOT ILIKE` (PostgreSQL/Redshift-specific)
+    PGNotILikeMatch,
     /// PostgreSQL-specific custom operator.
     ///
     /// See [CREATE OPERATOR](https://www.postgresql.org/docs/current/sql-createoperator.html)
@@ -188,6 +196,10 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::PGRegexIMatch => f.write_str("~*"),
             BinaryOperator::PGRegexNotMatch => f.write_str("!~"),
             BinaryOperator::PGRegexNotIMatch => f.write_str("!~*"),
+            BinaryOperator::PGLikeMatch => f.write_str("~~"),
+            BinaryOperator::PGILikeMatch => f.write_str("~~*"),
+            BinaryOperator::PGNotLikeMatch => f.write_str("!~~"),
+            BinaryOperator::PGNotILikeMatch => f.write_str("!~~*"),
             BinaryOperator::PGCustomBinaryOperator(idents) => {
                 write!(f, "OPERATOR({})", display_separated(idents, "."))
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3035,8 +3035,12 @@ impl<'a> Parser<'a> {
             }
             Token::Tilde => Some(BinaryOperator::PGRegexMatch),
             Token::TildeAsterisk => Some(BinaryOperator::PGRegexIMatch),
+            Token::DoubleTilde => Some(BinaryOperator::PGLikeMatch),
+            Token::DoubleTildeAsterisk => Some(BinaryOperator::PGILikeMatch),
             Token::ExclamationMarkTilde => Some(BinaryOperator::PGRegexNotMatch),
             Token::ExclamationMarkTildeAsterisk => Some(BinaryOperator::PGRegexNotIMatch),
+            Token::ExclamationMarkDoubleTilde => Some(BinaryOperator::PGNotLikeMatch),
+            Token::ExclamationMarkDoubleTildeAsterisk => Some(BinaryOperator::PGNotILikeMatch),
             Token::Word(w) => match w.keyword {
                 Keyword::AND => Some(BinaryOperator::And),
                 Keyword::OR => Some(BinaryOperator::Or),
@@ -3667,8 +3671,12 @@ impl<'a> Parser<'a> {
             | Token::DoubleEq
             | Token::Tilde
             | Token::TildeAsterisk
+            | Token::DoubleTilde
+            | Token::DoubleTildeAsterisk
             | Token::ExclamationMarkTilde
             | Token::ExclamationMarkTildeAsterisk
+            | Token::ExclamationMarkDoubleTilde
+            | Token::ExclamationMarkDoubleTildeAsterisk
             | Token::Spaceship => Ok(20),
             Token::Gt => {
                 // Two consecutive > tokens form >> (shift right) at higher precedence

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -147,10 +147,18 @@ pub enum Token {
     Tilde,
     /// `~*` , a case insensitive match regular expression operator in PostgreSQL
     TildeAsterisk,
+    /// `~~`, a case sensitive match (LIKE) operator in PostgreSQL/Redshift
+    DoubleTilde,
+    /// `~~*`, a case insensitive match (ILIKE) operator in PostgreSQL/Redshift
+    DoubleTildeAsterisk,
     /// `!~` , a case sensitive not match regular expression operator in PostgreSQL
     ExclamationMarkTilde,
     /// `!~*` , a case insensitive not match regular expression operator in PostgreSQL
     ExclamationMarkTildeAsterisk,
+    /// `!~~`, a case sensitive not match (NOT LIKE) operator in PostgreSQL/Redshift
+    ExclamationMarkDoubleTilde,
+    /// `!~~*`, a case insensitive not match (NOT ILIKE) operator in PostgreSQL/Redshift
+    ExclamationMarkDoubleTildeAsterisk,
     /// `<<`, a bitwise shift left operator in PostgreSQL
     ShiftLeft,
     /// `>>`, a bitwise shift right operator in PostgreSQL
@@ -253,8 +261,12 @@ impl fmt::Display for Token {
             Token::DoubleExclamationMark => f.write_str("!!"),
             Token::Tilde => f.write_str("~"),
             Token::TildeAsterisk => f.write_str("~*"),
+            Token::DoubleTilde => f.write_str("~~"),
+            Token::DoubleTildeAsterisk => f.write_str("~~*"),
             Token::ExclamationMarkTilde => f.write_str("!~"),
             Token::ExclamationMarkTildeAsterisk => f.write_str("!~*"),
+            Token::ExclamationMarkDoubleTilde => f.write_str("!~~"),
+            Token::ExclamationMarkDoubleTildeAsterisk => f.write_str("!~~*"),
             Token::AtSign => f.write_str("@"),
             Token::ShiftLeft => f.write_str("<<"),
             Token::ShiftRight => f.write_str(">>"),
@@ -1090,6 +1102,16 @@ impl<'a> Tokenizer<'a> {
                             match chars.peek() {
                                 Some('*') => self
                                     .consume_and_return(chars, Token::ExclamationMarkTildeAsterisk),
+                                Some('~') => {
+                                    chars.next();
+                                    match chars.peek() {
+                                        Some('*') => self.consume_and_return(
+                                            chars,
+                                            Token::ExclamationMarkDoubleTildeAsterisk,
+                                        ),
+                                        _ => Ok(Some(Token::ExclamationMarkDoubleTilde)),
+                                    }
+                                }
                                 _ => Ok(Some(Token::ExclamationMarkTilde)),
                             }
                         }
@@ -1154,6 +1176,15 @@ impl<'a> Tokenizer<'a> {
                     chars.next(); // consume
                     match chars.peek() {
                         Some('*') => self.consume_and_return(chars, Token::TildeAsterisk),
+                        Some('~') => {
+                            chars.next();
+                            match chars.peek() {
+                                Some('*') => {
+                                    self.consume_and_return(chars, Token::DoubleTildeAsterisk)
+                                }
+                                _ => Ok(Some(Token::DoubleTilde)),
+                            }
+                        }
                         _ => Ok(Some(Token::Tilde)),
                     }
                 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1970,6 +1970,36 @@ fn parse_pg_regex_match_ops() {
 }
 
 #[test]
+fn parse_pg_like_match_ops() {
+    // Operator-form aliases for LIKE / ILIKE / NOT LIKE / NOT ILIKE.
+    // Postgres docs: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+    // Redshift docs: https://docs.aws.amazon.com/redshift/latest/dg/pattern-matching-conditions-like.html
+    // Both engines emit these forms from `pg_get_viewdef` / `SHOW VIEW`,
+    // so any reparser that round-trips view definitions must accept them.
+    let pg_like_match_ops = &[
+        ("~~", BinaryOperator::PGLikeMatch),
+        ("~~*", BinaryOperator::PGILikeMatch),
+        ("!~~", BinaryOperator::PGNotLikeMatch),
+        ("!~~*", BinaryOperator::PGNotILikeMatch),
+    ];
+
+    for (str_op, op) in pg_like_match_ops {
+        let select = pg().verified_only_select(&format!("SELECT 'abc' {} 'a%'", &str_op));
+        assert_eq!(
+            SelectItem::UnnamedExpr(
+                Expr::BinaryOp {
+                    left: Box::new(Expr::Value(Value::SingleQuotedString("abc".into()))),
+                    op: op.clone(),
+                    right: Box::new(Expr::Value(Value::SingleQuotedString("a%".into()))),
+                }
+                .empty_span()
+            ),
+            select.projection[0].clone().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parse_array_index_expr() {
     let num: Vec<Expr> = (0..=10)
         .map(|s| Expr::Value(number(&s.to_string())))

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -317,6 +317,18 @@ fn redshift() -> TestedDialects {
     }
 }
 
+#[test]
+fn parse_pg_like_match_ops_in_view_body() {
+    // `pg_get_viewdef` / `SHOW VIEW` in Redshift normalize ILIKE / NOT ILIKE
+    // to their operator-form aliases `~~*` and `!~~*` (and LIKE / NOT LIKE to
+    // `~~` and `!~~`). Reparsing exported view DDL therefore requires accepting
+    // these tokens. See:
+    // https://docs.aws.amazon.com/redshift/latest/dg/pattern-matching-conditions-like.html
+    let sql = "SELECT * FROM t WHERE \
+        (t.a ~~ 'a%') AND (t.b ~~* 'b%') AND (t.c !~~ 'c%') AND (t.d !~~* 'd%')";
+    redshift().verified_stmt(sql);
+}
+
 fn redshift_unescaped() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(RedshiftSqlDialect {})],


### PR DESCRIPTION
## Summary

Adds tokenizer + parser support for the operator-form aliases of `LIKE`, `ILIKE`, `NOT LIKE`, `NOT ILIKE`:

- `~~`  → `BinaryOperator::PGLikeMatch`
- `~~*` → `BinaryOperator::PGILikeMatch`
- `!~~` → `BinaryOperator::PGNotLikeMatch`
- `!~~*` → `BinaryOperator::PGNotILikeMatch`

Both PostgreSQL and Redshift emit these forms in `pg_get_viewdef` / `SHOW VIEW` output, so any reparser that round-trips view definitions (e.g. CLL feeding off Redshift system / user view DDL) must accept them.

## Why this matters

Surfaced during PR-7179 residual-error analysis: a chunk of failing real-world Redshift view definitions all reported `Expected joined table, found: .` deep inside doubly-parenthesized JOIN trees. The actual trigger was an unsupported `~~*` operator inside a WHERE predicate of one of the inner `SELECT` arms — the parse failure cascaded up through nested derived-table backtracking, producing a misleading error far from the real cause.

## Grammar reference

PostgreSQL — https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

> The keyword ILIKE can be used instead of LIKE to make the match case-insensitive according to the active locale. This is not in the SQL standard but is a PostgreSQL extension.
> The operator `~~` is equivalent to LIKE, and `~~*` corresponds to ILIKE. There are also `!~~` and `!~~*` operators that represent NOT LIKE and NOT ILIKE, respectively.

Redshift — https://docs.aws.amazon.com/redshift/latest/dg/pattern-matching-conditions-like.html

> `~~` and `!~~` work like LIKE and NOT LIKE, while `~~*` and `!~~*` work like ILIKE and NOT ILIKE.

## Implementation notes

- Tokenizer uses longest-match for `~` / `!~` so `~~` / `~~*` / `!~~` / `!~~*` win over the existing `~` / `~*` / `!~` / `!~*` regex tokens.
- Operators get the same precedence (20) as the existing PG regex operators in `parse_infix`.
- Generic `~~` parsing previously succeeded *syntactically* (parsed as `~` then unary `~`), producing semantically wrong AST. After this change it parses as `PGLikeMatch`.

## Tests

- 1008 unit tests pass (2 new: `parse_pg_like_match_ops`, `parse_pg_like_match_ops_in_view_body`).
- Corpus: zero delta, zero regressions (the failing customer SQL isn't in the corpus snapshot — this is a tier-0 / tier-1 fix per `.claude/fix-corpus-loop.md`).