### PR TITLE
bigquery: parse CREATE PROCEDURE BEGIN…END body without AS keyword

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15223,10 +15223,17 @@ impl<'a> Parser<'a> {
         // Skip optional clauses until AS keyword (LANGUAGE, EXECUTE AS CALLER, etc.).
         // Snowflake procedures may omit the body entirely when using HANDLER +
         // IMPORTS — allow EOF / `;` as a clean exit with no body.
+        // BigQuery procedure bodies start with `BEGIN` directly (no `AS`
+        // keyword), so treat a leading `BEGIN` as an implicit body start when
+        // the AS keyword has not been seen.
         let mut has_body = false;
         loop {
             match self.peek_token_kind() {
                 Token::EOF | Token::SemiColon => break,
+                Token::Word(w) if w.keyword == Keyword::BEGIN => {
+                    has_body = true;
+                    break;
+                }
                 _ => {}
             }
             if self.parse_keywords(&[Keyword::EXECUTE, Keyword::AS]) {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2204,6 +2204,49 @@ fn test_bigquery_expr_wildcard_after_subscript() {
 }
 
 #[test]
+fn test_bigquery_create_procedure_begin_end_body() {
+    // BigQuery procedure bodies start with `BEGIN` directly — no `AS` keyword
+    // before the body. The parser must populate `body: Vec<Statement>` so
+    // downstream consumers (lineage, syntax-check tools) can walk the body.
+    // Reference: https://cloud.google.com/bigquery/docs/procedures
+    let sql = "CREATE OR REPLACE PROCEDURE proj.ds.p() BEGIN \
+               CREATE TEMP TABLE t AS SELECT id FROM proj.ds.src; \
+               INSERT INTO proj.ds.dst (id) SELECT id FROM t; \
+               END";
+    let stmts = bigquery().parse_sql_statements(sql).unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Statement::CreateProcedure { body, body_definition, .. } => {
+            assert!(body_definition.is_none(), "expected BEGIN/END body, not string");
+            assert_eq!(
+                body.len(),
+                2,
+                "expected 2 inner statements (CREATE TEMP TABLE + INSERT), got {body:?}"
+            );
+            assert!(matches!(body[0], Statement::CreateTable { .. }));
+            assert!(matches!(body[1], Statement::Insert { .. }));
+        }
+        other => panic!("expected CreateProcedure, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_bigquery_create_procedure_empty_body() {
+    // BigQuery procedure with no body (OPTIONS-only or trailing `;`) should
+    // still parse successfully with `body: vec![]`.
+    let sql = "CREATE PROCEDURE proj.ds.p()";
+    let stmts = bigquery().parse_sql_statements(sql).unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Statement::CreateProcedure { body, body_definition, .. } => {
+            assert!(body.is_empty());
+            assert!(body_definition.is_none());
+        }
+        other => panic!("expected CreateProcedure, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_bigquery_materialized_view_unparenthesized_cluster_by() {
     // BigQuery `CREATE MATERIALIZED VIEW ... CLUSTER BY col` lists the
     // clustering columns without parentheses, unlike ClickHouse.


### PR DESCRIPTION
## Summary
- BigQuery procedure bodies start with `BEGIN` directly — no `AS` keyword between params and body. Today `parse_create_procedure` waits for `AS`, so a BigQuery procedure parses with `body: vec![]` and the inner statements get swallowed or re-parsed as separate top-level statements with no procedure context.
- Treat a peeked `BEGIN` as an implicit body start so the existing BEGIN/END branch picks up the inner `Vec<Statement>`.
- Unblocks column-level lineage threading inside BigQuery procedures in kernel-cll (cloud PR follows).

## Reference
- BigQuery procedure syntax: https://cloud.google.com/bigquery/docs/procedures

## Tests
- New: \`test_bigquery_create_procedure_begin_end_body\` — verifies `body` is populated with the inner CREATE TEMP TABLE + INSERT.
- New: \`test_bigquery_create_procedure_empty_body\` — pins down the no-body form still works (`body: vec![]`, no body string).
- Full suite: \`cargo nextest run --all-features\` — 1008 pass.