### PR TITLE
sqlparser: close PR-7185 parser gaps (FINAL/SORT aliases, BigQuery numeric project IDs, view column annotations)

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -133,6 +133,7 @@ define_keywords!(
     BTREE,
     BY,
     BYPASSRLS,
+    BYTE,
     BYTEA,
     BYTES,
     CACHE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10198,9 +10198,13 @@ impl<'a> Parser<'a> {
             return Ok(CharacterLength::Max);
         }
         let length = self.parse_literal_uint()?;
-        let unit = if self.parse_keyword(Keyword::CHARACTERS) {
+        // Standard SQL spells the length unit as CHARACTERS / OCTETS. Snowflake
+        // (and Oracle-style dialects) use CHAR / BYTE — accept both spellings
+        // and map to the same enum variants.
+        // https://docs.snowflake.com/en/sql-reference/data-types-text
+        let unit = if self.parse_keyword(Keyword::CHARACTERS) || self.parse_keyword(Keyword::CHAR) {
             Some(CharLengthUnits::Characters)
-        } else if self.parse_keyword(Keyword::OCTETS) {
+        } else if self.parse_keyword(Keyword::OCTETS) || self.parse_keyword(Keyword::BYTE) {
             Some(CharLengthUnits::Octets)
         } else {
             None

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9599,6 +9599,14 @@ impl<'a> Parser<'a> {
             {
                 Ok(Some(w.to_ident().spanning(next_token.span)))
             }
+            // FINAL is reserved only for ClickHouse's `FROM t FINAL` clause.
+            // In other dialects (Postgres/Redshift/Snowflake/BigQuery/...) it
+            // is a regular identifier — e.g. `FROM (...) final`.
+            Token::Word(w)
+                if w.keyword == Keyword::FINAL && !dialect_of!(self is ClickHouseDialect) =>
+            {
+                Ok(Some(w.to_ident().spanning(next_token.span)))
+            }
             // MSSQL supports single-quoted strings as aliases for columns
             // We accept them as table aliases too, although MSSQL does not.
             //

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11173,7 +11173,13 @@ impl<'a> Parser<'a> {
                         SetQuantifier::All
                     }
                 } else if self.parse_keyword(Keyword::DISTINCT) {
-                    SetQuantifier::Distinct
+                    // `UNION DISTINCT BY NAME` (Snowflake/BigQuery) — DISTINCT
+                    // is the default for UNION, so the BY NAME modifier wins.
+                    if self.parse_keywords(&[Keyword::BY, Keyword::NAME]) {
+                        SetQuantifier::ByName
+                    } else {
+                        SetQuantifier::Distinct
+                    }
                 } else {
                     SetQuantifier::None
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4152,6 +4152,11 @@ impl<'a> Parser<'a> {
                     // Clause keywords that are never function names — a trailing
                     // `,` followed by one of these always ends the projection
                     // list, regardless of what follows (e.g. `FROM (SELECT ...)`).
+                    // OFFSET is intentionally excluded — it never appears as
+                    // a top-level clause keyword *immediately* after a SELECT
+                    // projection (it always follows LIMIT / FETCH / FROM …),
+                    // and BigQuery/Snowflake legitimately use it as a column
+                    // name (`select a, offset as pagination_offset`).
                     let is_clause_only = matches!(
                         kw.keyword,
                         Keyword::FROM
@@ -4160,7 +4165,6 @@ impl<'a> Parser<'a> {
                             | Keyword::HAVING
                             | Keyword::ORDER
                             | Keyword::LIMIT
-                            | Keyword::OFFSET
                             | Keyword::QUALIFY
                             | Keyword::WINDOW
                             | Keyword::UNION

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9999,7 +9999,19 @@ impl<'a> Parser<'a> {
     ) -> Result<WithSpan<Ident>, ParserError> {
         let ident = self.parse_identifier(false)?;
         let mut consumed_policy_or_tag = false;
+        // Snowflake column-level annotations after the column name in a CREATE
+        // VIEW column list:
+        //   [ COMMENT '...' ]
+        //   [ [WITH] MASKING POLICY p [USING (col, ...)] ]
+        //   [ [WITH] PROJECTION POLICY p ]
+        //   [ [WITH] TAG (k = 'v', ...) ]
+        // The official docs spell COMMENT first, but generators emit them in
+        // either order — accept any interleaving.
         loop {
+            if self.parse_keyword(Keyword::COMMENT) {
+                self.parse_literal_string()?;
+                continue;
+            }
             let with = self.parse_keyword(Keyword::WITH);
             if self.parse_keywords(&[Keyword::MASKING, Keyword::POLICY]) {
                 let _ = self.parse_object_name(false)?;
@@ -10024,22 +10036,7 @@ impl<'a> Parser<'a> {
         if !consumed_policy_or_tag {
             // Optionally skip data type for PostgreSQL/Redshift table function column definitions.
             // e.g. FROM func() alias(col_name data_type, ...) where data_type is `name`, `varchar`, `int`, etc.
-            // Do not attempt if next token is a column annotation keyword (COMMENT)
-            // since that serves a different purpose and is handled below.
-            let is_annotation_keyword = matches!(
-                self.peek_token_kind(),
-                Token::Word(Word {
-                    keyword: Keyword::COMMENT,
-                    ..
-                })
-            );
-            if !is_annotation_keyword {
-                let _ = self.maybe_parse(|p| p.parse_data_type());
-            }
-        }
-        // Skip COMMENT clause if present
-        if self.parse_keyword(Keyword::COMMENT) {
-            self.parse_literal_string()?;
+            let _ = self.maybe_parse(|p| p.parse_data_type());
         }
         Ok(ident)
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1243,6 +1243,11 @@ impl<'a> Parser<'a> {
                     {
                         let name = ObjectName(vec![Ident::new("extract")]);
                         self.parse_function(name)
+                    } else if !self.peek_token_is(&Token::LParen) {
+                        // Bare identifier `extract` used as a column reference,
+                        // e.g. `nullif(extract, '')` — Redshift/Postgres allow
+                        // EXTRACT as a column name when not followed by `(`.
+                        Ok(Expr::Identifier(w.to_ident().spanning(next_token.span)))
                     } else {
                         self.parse_extract_expr()
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12663,11 +12663,17 @@ impl<'a> Parser<'a> {
                 // CHANGES is always followed by AT and optionally END
             }
             // Snowflake AT/BEFORE time travel:
-            // table AT(TIMESTAMP => expr) or table BEFORE(STATEMENT => 'id')
-            let is_at = self.parse_keyword(Keyword::AT);
+            // table AT(TIMESTAMP => expr) or table BEFORE(STATEMENT => 'id').
+            // Only consume the keyword when it is actually followed by `(` —
+            // otherwise it is being used as a regular table alias, e.g.
+            // `JOIN tbl at ON ...`.
+            let is_at = matches!(
+                self.peek_tokens(),
+                [Token::Word(w), Token::LParen] if w.keyword == Keyword::AT,
+            ) && self.parse_keyword(Keyword::AT);
             let is_before = if !is_at {
-                match self.peek_token_kind().clone() {
-                    Token::Word(w) if w.value.to_uppercase() == "BEFORE" => {
+                match self.peek_tokens() {
+                    [Token::Word(w), Token::LParen] if w.value.to_uppercase() == "BEFORE" => {
                         self.next_token();
                         true
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12418,7 +12418,7 @@ impl<'a> Parser<'a> {
                     table_with_joins: Box::new(table_and_joins),
                     alias,
                 })
-            } else if dialect_of!(self is SnowflakeDialect | DatabricksDialect | BigQueryDialect | DuckDbDialect | AnsiDialect | GenericDialect)
+            } else if dialect_of!(self is SnowflakeDialect | DatabricksDialect | BigQueryDialect | DuckDbDialect | AnsiDialect | GenericDialect | PostgreSqlDialect | RedshiftSqlDialect)
             {
                 // Dialect-specific behavior: several dialects diverge from the
                 // standard and from most of the other implementations by

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9586,12 +9586,13 @@ impl<'a> Parser<'a> {
             Token::Word(w) if after_as || !reserved_kwds.contains(&w.keyword) => {
                 Ok(Some(w.to_ident().spanning(next_token.span)))
             }
-            // CLUSTER is reserved only because of `CLUSTER BY` (Hive/Spark
-            // SELECT-level clause and Snowflake/BigQuery DDL clause). When the
-            // following token is not BY, the keyword is being used as a regular
-            // identifier alias — e.g. BigQuery `JOIN tbl cluster ON ...`.
+            // CLUSTER / SORT are reserved only because of `CLUSTER BY` /
+            // `SORT BY` (Hive/Spark SELECT-level clauses and Snowflake/BigQuery
+            // DDL clauses). When the following token is not BY, the keyword
+            // is being used as a regular identifier alias — e.g. BigQuery
+            // `JOIN tbl cluster ON ...` or Snowflake `FROM t sort`.
             Token::Word(w)
-                if w.keyword == Keyword::CLUSTER
+                if (w.keyword == Keyword::CLUSTER || w.keyword == Keyword::SORT)
                     && !matches!(
                         self.peek_token_kind(),
                         Token::Word(next) if next.keyword == Keyword::BY,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4191,6 +4191,20 @@ impl<'a> Parser<'a> {
                             Token::Word(w2) if w2.keyword == Keyword::AS => false,
                             // `cluster.x` — qualified column reference.
                             Token::Period => false,
+                            // `offset + 1`, `offset - 1`, `offset * n`, etc.
+                            // — column being used in an arithmetic expression.
+                            Token::Plus
+                            | Token::Minus
+                            | Token::Mul
+                            | Token::Div
+                            | Token::Mod
+                            | Token::StringConcat
+                            | Token::Eq
+                            | Token::Neq
+                            | Token::Lt
+                            | Token::LtEq
+                            | Token::Gt
+                            | Token::GtEq => false,
                             _ => true,
                         }
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9911,6 +9911,27 @@ impl<'a> Parser<'a> {
                                 ident.value.push_str(&s);
                                 true
                             }
+                            // BigQuery accepts numeric segments as part of an
+                            // unquoted hyphenated project ID, e.g.
+                            // `root-rarity-166622.scores.ds`. The tokenizer
+                            // greedily folds the trailing `.` into the number
+                            // (yielding `Number("166622.")`); take the digit
+                            // prefix as the continuation and rewrite the
+                            // current token to a Period so the surrounding
+                            // `parse_object_name` loop continues with the
+                            // project/dataset separator.
+                            Token::Number(s, false)
+                                if s.ends_with('.')
+                                    && s[..s.len() - 1].chars().all(|c| c.is_ascii_digit()) =>
+                            {
+                                ident.value.push_str(&s[..s.len() - 1]);
+                                let idx = self.index - 1;
+                                if let Some(t) = self.tokens.get_mut(idx) {
+                                    t.token = Token::Period;
+                                }
+                                self.prev_token();
+                                false
+                            }
                             _ => {
                                 return self
                                     .expected("continuation of hyphenated identifier", token);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1593,6 +1593,31 @@ impl<'a> Tokenizer<'a> {
                         return Ok(s);
                     }
                 }
+                // BigQuery raw strings (`r'...'`) preserve backslashes
+                // literally, but `\<quote>` is a two-character sequence that
+                // does not terminate the string — e.g. `r'[\']'` is the
+                // regex character class `[\']`. Only escape the quote
+                // itself; everything else (including `\\`) stays as-is so
+                // patterns like `r"\\foo\"` keep the original byte stream.
+                // See
+                // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+                '\\' if !allow_backslash_escape
+                    && dialect_of!(self is BigQueryDialect | GenericDialect)
+                    && matches!(
+                        {
+                            let mut la = chars.peekable.clone();
+                            la.next();
+                            la.peek().copied()
+                        },
+                        Some(c) if c == quote_style,
+                    ) =>
+                {
+                    chars.next(); // consume the backslash
+                    s.push(ch);
+                    let next_ch = *chars.peek().unwrap();
+                    s.push(next_ch);
+                    chars.next();
+                }
                 '\\' if allow_backslash_escape => {
                     chars.next();
                     if dialect_of!(self is MySqlDialect | BigQueryDialect | RedshiftSqlDialect | DatabricksDialect | SnowflakeDialect | ClickHouseDialect)

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2272,3 +2272,17 @@ fn test_bigquery_materialized_view_unparenthesized_cluster_by() {
         )
         .unwrap();
 }
+
+#[test]
+fn test_bigquery_hyphenated_project_id_with_numeric_segment() {
+    // BigQuery permits hyphen-separated segments in unquoted project IDs to
+    // be numeric, e.g. `root-rarity-166622.scores.ds`. The tokenizer folds
+    // the trailing `.` into the number (`166622.`); the table-clause path
+    // accepts that form and continues the dotted name parsing.
+    bigquery()
+        .parse_sql_statements("SELECT * FROM root-rarity-166622.scores.ds")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements("SELECT * FROM proj-228706.dataset.tbl")
+        .unwrap();
+}

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2304,3 +2304,17 @@ fn test_bigquery_offset_in_arithmetic_projection() {
         .parse_sql_statements("SELECT a, offset >= 0 AS pos FROM t")
         .unwrap();
 }
+
+#[test]
+fn test_bigquery_raw_string_escaped_quote() {
+    // BigQuery raw string literals preserve backslashes literally, but
+    // `\'` (or `\"`) is a two-character sequence that does not terminate
+    // the string — typically used inside regex character classes.
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+    bigquery()
+        .parse_sql_statements(r"SELECT REGEXP_REPLACE(x, r'[^\p{L}{0-9} \'\.\-\/\(\)]', '') FROM t")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements(r#"SELECT r"escaped \" quote stays in string""#)
+        .unwrap();
+}

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2216,8 +2216,15 @@ fn test_bigquery_create_procedure_begin_end_body() {
     let stmts = bigquery().parse_sql_statements(sql).unwrap();
     assert_eq!(stmts.len(), 1);
     match &stmts[0] {
-        Statement::CreateProcedure { body, body_definition, .. } => {
-            assert!(body_definition.is_none(), "expected BEGIN/END body, not string");
+        Statement::CreateProcedure {
+            body,
+            body_definition,
+            ..
+        } => {
+            assert!(
+                body_definition.is_none(),
+                "expected BEGIN/END body, not string"
+            );
             assert_eq!(
                 body.len(),
                 2,
@@ -2238,7 +2245,11 @@ fn test_bigquery_create_procedure_empty_body() {
     let stmts = bigquery().parse_sql_statements(sql).unwrap();
     assert_eq!(stmts.len(), 1);
     match &stmts[0] {
-        Statement::CreateProcedure { body, body_definition, .. } => {
+        Statement::CreateProcedure {
+            body,
+            body_definition,
+            ..
+        } => {
             assert!(body.is_empty());
             assert!(body_definition.is_none());
         }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2286,3 +2286,21 @@ fn test_bigquery_hyphenated_project_id_with_numeric_segment() {
         .parse_sql_statements("SELECT * FROM proj-228706.dataset.tbl")
         .unwrap();
 }
+
+#[test]
+fn test_bigquery_offset_in_arithmetic_projection() {
+    // BigQuery `WITH OFFSET` exposes `offset` as a column the projection
+    // can use. Ensure trailing-comma handling still parses
+    //   SELECT a, offset + 1 AS bar FROM t
+    // (and similar arithmetic / comparison shapes) where `offset` is the
+    // column on the left of an operator.
+    bigquery()
+        .parse_sql_statements("SELECT a, offset + 1 AS bar FROM t")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements("SELECT a, offset - 1, offset * 2 FROM t")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements("SELECT a, offset >= 0 AS pos FROM t")
+        .unwrap();
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -749,3 +749,16 @@ fn test_redshift_extract_as_identifier() {
         .parse_sql_statements("SELECT EXTRACT(YEAR FROM ts) FROM t")
         .unwrap();
 }
+
+#[test]
+fn test_redshift_postgres_bare_parens_around_table() {
+    // PostgreSQL / Redshift accept superfluous parentheses around a single
+    // FROM-clause table reference (e.g. `FROM (mytable)`), matching the
+    // permissive behaviour Snowflake/BigQuery already had.
+    redshift()
+        .parse_sql_statements("SELECT a FROM (mytable)")
+        .unwrap();
+    redshift()
+        .parse_sql_statements("SELECT a FROM (mytable) AS m")
+        .unwrap();
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -719,3 +719,16 @@ fn test_redshift_partiql_unnest_at_position() {
         )
         .unwrap();
 }
+
+#[test]
+fn test_redshift_final_as_table_alias() {
+    // `final` is not a reserved keyword in Postgres/Redshift, so it must be
+    // accepted as a regular table alias. It is reserved only in ClickHouse
+    // (for `FROM t FINAL`).
+    redshift()
+        .parse_sql_statements("SELECT final.id FROM (SELECT 1 AS id) final")
+        .unwrap();
+    redshift()
+        .parse_sql_statements("SELECT final.id FROM (SELECT 1 AS id) AS final")
+        .unwrap();
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -732,3 +732,20 @@ fn test_redshift_final_as_table_alias() {
         .parse_sql_statements("SELECT final.id FROM (SELECT 1 AS id) AS final")
         .unwrap();
 }
+
+#[test]
+fn test_redshift_extract_as_identifier() {
+    // EXTRACT is the date-extract function only when followed by `(`. As a
+    // bare identifier (column name) it is allowed in Redshift / Postgres,
+    // and dbt-style projections expose it directly.
+    redshift()
+        .parse_sql_statements("SELECT NULLIF(extract, '')::VARCHAR(4096) AS extract FROM t")
+        .unwrap();
+    redshift()
+        .parse_sql_statements("SELECT t.extract FROM t WHERE t.extract IS NOT NULL")
+        .unwrap();
+    // Real EXTRACT(field FROM expr) still parses.
+    redshift()
+        .parse_sql_statements("SELECT EXTRACT(YEAR FROM ts) FROM t")
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2865,3 +2865,12 @@ fn test_snowflake_offset_as_column_name() {
         .parse_sql_statements("SELECT (SELECT a, offset FROM t)")
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_union_distinct_by_name() {
+    // Snowflake/BigQuery accept `UNION DISTINCT BY NAME` — DISTINCT is
+    // already implicit, so the BY NAME modifier governs how columns line up.
+    snowflake()
+        .parse_sql_statements("SELECT a FROM t1 UNION DISTINCT BY NAME SELECT a FROM t2")
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2810,3 +2810,25 @@ fn test_snowflake_sort_as_table_alias() {
         .parse_sql_statements("SELECT sort.id FROM (SELECT 1 AS id) AS sort")
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_view_column_comment_then_policy() {
+    // Snowflake CREATE VIEW column list permits per-column annotations in any
+    // order: COMMENT '...', MASKING POLICY p [USING (...)], PROJECTION POLICY p,
+    // TAG (k='v', ...). Generators emit them after the COMMENT clause.
+    snowflake()
+        .parse_sql_statements(
+            "CREATE OR REPLACE VIEW v (c1, c2 COMMENT 'x' MASKING POLICY p) AS SELECT a, b FROM t",
+        )
+        .unwrap();
+    snowflake()
+        .parse_sql_statements(
+            "CREATE OR REPLACE VIEW v (c1 COMMENT 'a', c2 COMMENT 'b' WITH TAG (env = 'prod')) AS SELECT a, b FROM t",
+        )
+        .unwrap();
+    snowflake()
+        .parse_sql_statements(
+            "CREATE OR REPLACE VIEW v (c1 MASKING POLICY p COMMENT 'a') AS SELECT a FROM t",
+        )
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2797,3 +2797,16 @@ fn test_snowflake_execute_immediate_from() {
         .parse_sql_statements("EXECUTE IMMEDIATE FROM '@mystage/script.sql'")
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_sort_as_table_alias() {
+    // SORT is reserved only because of `SORT BY` (Hive/Spark). In Snowflake
+    // and most other dialects, `sort` is a regular identifier and may be
+    // used as a table alias — e.g. `FROM t SORT` followed by `SORT.col`.
+    snowflake()
+        .parse_sql_statements("SELECT SORT.NAME AS SALES_ORDER_TYPE_NAME FROM t SORT")
+        .unwrap();
+    snowflake()
+        .parse_sql_statements("SELECT sort.id FROM (SELECT 1 AS id) AS sort")
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2851,3 +2851,17 @@ fn test_snowflake_at_as_table_alias() {
         .parse_sql_statements("SELECT * FROM t AT (TIMESTAMP => '2024-01-01'::TIMESTAMP)")
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_offset_as_column_name() {
+    // OFFSET never appears as a clause keyword immediately after a SELECT
+    // projection — LIMIT/FETCH/FROM always come first — so accept it as a
+    // column name in the projection list. Real customer pattern:
+    //   SELECT a, offset AS pagination_offset FROM t
+    snowflake()
+        .parse_sql_statements("SELECT a, offset AS pagination_offset FROM t")
+        .unwrap();
+    snowflake()
+        .parse_sql_statements("SELECT (SELECT a, offset FROM t)")
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2832,3 +2832,22 @@ fn test_snowflake_view_column_comment_then_policy() {
         )
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_at_as_table_alias() {
+    // Snowflake AT/BEFORE time travel must only be consumed when followed
+    // by `(`, otherwise `at` is a plain table alias — e.g.
+    // `INNER JOIN absencetype at ON at.id = ...`.
+    snowflake()
+        .parse_sql_statements(
+            "SELECT * FROM t1 INNER JOIN absencetype at ON at.id = t1.absencetype_id",
+        )
+        .unwrap();
+    snowflake()
+        .parse_sql_statements("SELECT * FROM t1 LEFT JOIN absencetype before ON before.id = t1.id")
+        .unwrap();
+    // Time travel still parses normally.
+    snowflake()
+        .parse_sql_statements("SELECT * FROM t AT (TIMESTAMP => '2024-01-01'::TIMESTAMP)")
+        .unwrap();
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2874,3 +2874,19 @@ fn test_snowflake_union_distinct_by_name() {
         .parse_sql_statements("SELECT a FROM t1 UNION DISTINCT BY NAME SELECT a FROM t2")
         .unwrap();
 }
+
+#[test]
+fn test_snowflake_varchar_char_byte_length_units() {
+    // Snowflake (Oracle-style) accepts CHAR / BYTE as the length unit on
+    // character types in addition to the SQL-standard CHARACTERS / OCTETS.
+    // https://docs.snowflake.com/en/sql-reference/data-types-text
+    snowflake()
+        .parse_sql_statements("SELECT CAST(NULL AS VARCHAR(25 CHAR))")
+        .unwrap();
+    snowflake()
+        .parse_sql_statements("SELECT CAST(NULL AS VARCHAR(255 BYTE))")
+        .unwrap();
+    snowflake()
+        .parse_sql_statements("SELECT CAST(NULL AS CHAR(10 CHAR))")
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

Closes the parser gaps in [PR-7185](https://linear.app/synq/issue/PR-7185) (kernel-cll: 34 view definitions failing). Verified by re-parsing every flagged view body via `latest_sql_definitions`.

**Result: 11 / 16 flagged view bodies now parse, +2 corpus pass-rate, 0 regressions, 1021 unit tests pass.** The remaining 5 are not parser bugs — see *Skipped (invalid source)* below.

### Fixes (12 commits, one per concern)

| # | Commit | Notes |
|---|---|---|
| 1 | `fix(redshift,postgres): accept FINAL as table alias outside ClickHouse` | Multiple real customer views use `FROM (...) final` |
| 2 | `fix(snowflake,bigquery,redshift): accept SORT as table alias outside Hive/Spark` | `JOIN tbl SORT ON …` real customer pattern |
| 3 | `fix(bigquery): accept numeric segments in hyphenated project IDs` | `proj-NNN.dataset.tbl` — **+2 corpus** |
| 4 | `fix(snowflake): allow COMMENT and MASKING/PROJECTION/TAG in any order on view columns` | Snowflake CREATE VIEW column-annotation reorderings |
| 5 | `fix(snowflake): require parens for AT/BEFORE time travel so 'at' can be a table alias` | `JOIN tbl at ON …` real customer pattern |
| 6 | `fix: accept OFFSET as column name in SELECT projection lists` | `, offset AS some_alias` real customer pattern |
| 7 | `fix: keep projection going when reserved keyword starts an arithmetic expression` | `, offset + 1 AS …` real customer pattern |
| 8 | `fix(snowflake,bigquery): accept UNION DISTINCT BY NAME` | Set-op qualifier between regional CTEs |
| 9 | `fix(bigquery): treat backslash-escaped quote inside raw strings as content` | `r'[^\p{L} \'\.\-\/\(\)]'` regex |
| 10 | `fix(snowflake): accept CHAR / BYTE length units on VARCHAR / CHAR` | `CAST(NULL AS VARCHAR(25 CHAR))` |
| 11 | `fix: accept bare EXTRACT as identifier when not followed by parenthesis` | `NULLIF(extract, '')::VARCHAR(4096) AS extract` |
| 12 | `fix(redshift,postgres): accept bare parentheses around a single table reference` | Postgres/Redshift `FROM (t)` |

Every commit has a primary-source docs citation in the body where the change introduces new syntax (per the corpus-loop "cite the docs" rule), plus a unit-test regression in the matching `tests/sqlparser_*.rs` file.

### Skipped (invalid source SQL — exit-hatch per `.claude/fix-corpus-loop.md`)

Confirmed by reading the actual view bodies pulled from production:

* Auto-generated `pg_catalog`-derived audit view with **hundreds of nested parens** (RecursionCounter limit, not a grammar bug). Needs a follow-up to raise / remove the depth limit safely.
* View body has a stray trailing comma after a JOIN's ON clause: `… ON tf.id = f.cf_id,` then `)` — not Snowflake-legal.
* View body is **truncated mid-statement** (ends with `, fraud_unnested,`).
* Two views with **missing commas in IN lists** (generator bugs hidden behind comments).

### Skipped (out-of-scope for this PR)

* **Snowflake `SEMANTIC_VIEW(... DIMENSIONS ... METRICS ... FACTS ...)`** — needs new AST nodes for the dimensions / metrics / facts clauses (these are column-level refs, so balanced-paren consumption is not acceptable per the loop guidance). Tracked separately in [PR-7186](https://linear.app/synq/issue/PR-7186).

### Verification

* `cargo nextest run --all-features` — 1021 passed, 0 failed
* `target/release/corpus-runner tests/corpus` — **+2 BigQuery, 0 regressions** vs `origin/main`
* All 11 fixed view bodies now parse cleanly

Refs: PR-7185