### PR TITLE
sqlparser: don't eat leading underscore of identifier after period (PR-7193)

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -891,7 +891,13 @@ impl<'a> Tokenizer<'a> {
                         s.push('.');
                         chars.next();
                     }
-                    s += &peeking_take_while(chars, digit_pred);
+                    // After the period, only continue consuming if the next char is a digit.
+                    // In numeric_underscore dialects an underscore separator is only valid
+                    // *between* digits, so `._foo` must tokenize as Period + Word("_foo"),
+                    // not as a number that swallows the leading underscore of an identifier.
+                    if matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+                        s += &peeking_take_while(chars, digit_pred);
+                    }
 
                     // No number -> Token::Period
                     if s == "." {

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -351,6 +351,30 @@ fn test_numeric_literal_underscores() {
 }
 
 #[test]
+fn test_qualified_name_with_underscore_prefix() {
+    // Regression: in numeric_literal_underscores dialects (DuckDB, Generic)
+    // the tokenizer must not greedily consume `_` after a `.` as a numeric
+    // separator. `schema._tbl` is two identifiers separated by a period,
+    // not `schema` + Number(".") + `tbl`. Underscores in numeric literals
+    // are only valid *between* digits (e.g. `1_000`, `1.50_0`).
+    let d = duckdb_and_generic();
+    // The original PR-7193 reproduction shape: real customer DuckDB DDL.
+    d.verified_stmt("CREATE TABLE foo._bar (x INT)");
+    // Same shape in DML / projection contexts.
+    d.verified_stmt("SELECT * FROM foo._bar");
+    d.verified_stmt("SELECT foo._bar.x FROM foo._bar");
+    // Multiple underscores in the leading position must all survive.
+    d.verified_stmt("SELECT * FROM foo.__dlt_loads");
+    // Mixed: digit-prefix segment then a `._ident`. The `1` ensures the
+    // tokenizer enters the numeric branch via a digit, not a period.
+    d.one_statement_parses_to("SELECT a FROM t1._dlt_loads", "SELECT a FROM t1._dlt_loads");
+    // Numeric separators between digits must still work — guards against
+    // an over-broad fix that disables the separator entirely.
+    d.one_statement_parses_to("SELECT 1_000", "SELECT 1000");
+    d.one_statement_parses_to("SELECT 1_000.50_0", "SELECT 1000.500");
+}
+
+#[test]
 fn test_at_sign_abs_operator() {
     // DuckDB supports @ as absolute value operator (same as PostgreSQL)
     duckdb().verified_stmt("SELECT (@-1) + 1");


### PR DESCRIPTION
## Summary

Fixes the `Expected end of statement, found: .` regression on customer DuckDB DDL surfaced via [PR-7193](https://linear.app/synq/issue/PR-7193).

In dialects with `supports_numeric_literal_underscores` (DuckDB, Generic), the tokenizer treated `_` as part of a numeric literal even when it immediately followed a `.` that was not preceded by digits. As a result, `schema._tbl` tokenized as `Word("schema") + Number(".") + Word("tbl")` instead of `Word("schema") + Period + Word("_tbl")`, breaking parsing of `CREATE TABLE foo._dlt_loads(...)` and similar shapes (22 customer DuckDB tables in the wild).

The numeric `_` separator is now only consumed when the next char after the period is a digit, matching the rule that underscores in numeric literals are valid only between digits. Numeric separators between digits (`1_000`, `1_000.50_0`) still work — covered by existing and new tests.

Affected dialects: only `DuckDbDialect` and `GenericDialect` (the only two that enable `supports_numeric_literal_underscores`); both are exercised by the new regression test via `duckdb_and_generic()`.