### PR TITLE
sqlparser-rs: wrap SEMANTIC VIEW Expr fields in WithSpan

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1378,7 +1378,7 @@ pub enum SemanticViewClause {
     Dimensions(Vec<SelectItem>),
     Metrics(Vec<SelectItem>),
     Facts(Vec<SelectItem>),
-    Where(Expr),
+    Where(WithSpan<Expr>),
 }
 
 impl fmt::Display for SemanticViewClause {
@@ -1844,7 +1844,7 @@ pub struct SemanticViewMember {
     pub qualified_name: ObjectName,
     pub modifiers: Vec<SemanticViewMemberModifier>,
     /// The body after `AS`.
-    pub expression: Expr,
+    pub expression: WithSpan<Expr>,
     pub synonyms: Vec<String>,
     pub comment: Option<String>,
     pub cortex_search: Option<SemanticViewCortexSearch>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13503,8 +13503,11 @@ impl<'a> Parser<'a> {
                 break;
             }
             if self.parse_keyword(Keyword::WHERE) {
+                let start_idx = self.index;
                 let expr = self.parse_expr()?;
-                clauses.push(SemanticViewClause::Where(expr));
+                clauses.push(SemanticViewClause::Where(
+                    expr.spanning(self.span_from_index(start_idx)),
+                ));
                 continue;
             }
             match self.peek_semantic_view_clause_keyword() {
@@ -13835,7 +13838,10 @@ impl<'a> Parser<'a> {
         }
 
         self.expect_keyword(Keyword::AS)?;
-        let expression = self.parse_expr()?;
+        let expr_start_idx = self.index;
+        let expression = self
+            .parse_expr()?
+            .spanning(self.span_from_index(expr_start_idx));
 
         let mut synonyms: Vec<String> = Vec::new();
         let mut comment: Option<String> = None;


### PR DESCRIPTION
## Summary

- Wrap `SemanticViewClause::Where(Expr)` and `SemanticViewMember.expression` in `WithSpan<Expr>` so downstream consumers (kernel-cll) can call `.span_location()` and emit `Expression` / `Projection` location kinds around SEMANTIC VIEW WHERE predicates and CREATE SEMANTIC VIEW member bodies.
- Parser sites in `parse_semantic_view_table_factor` and `parse_semantic_view_member` now record the start index before `parse_expr()` and `.spanning(...)` the result, mirroring the regular WHERE-selection pattern.
- Display impls unchanged (WithSpan forwards Display via Deref); all 1068 tests pass, including the 22 SEMANTIC VIEW round-trip tests.

[PR-7196](https://linear.app/synq/issue/PR-7196)