### PR TITLE
Improve corpus pass rate across dialects (89.8% → 94.9%, +8352 tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,10 @@ Use this pattern for dialect-specific clauses that don't need AST representation
 
 **Reserved-keyword-as-alias carve-out** (recurring fix shape):
 - When a keyword (e.g. CLUSTER, SORT, FINAL, AT, BEFORE) is reserved only because of a specific clause (`CLUSTER BY`, `t AT(...)` time-travel), accept it as an identifier alias in `parse_optional_alias` when the lookahead doesn't match the clause shape (next-not-`BY`, next-not-`(`, etc.).
-- Existing instances in `parse_optional_alias` for CLUSTER / SORT / FINAL and in `parse_table_factor` for AT / BEFORE serve as templates — copy the matching block rather than reinventing.
+- Existing instances in `parse_optional_alias` for CLUSTER / SORT / FINAL / VIEW / OPTION / USE/IGNORE/FORCE in `parse_table_factor` for AT / BEFORE serve as templates — copy the matching block rather than reinventing.
+- **Match-arm ordering trap:** the catch-all `Token::Word(w) if after_as || !reserved_kwds.contains(&w.keyword)` arm fires first for any non-reserved keyword. New carve-outs for dialect-specific clauses (e.g. `OPTION (`, `USE INDEX`) must be placed *before* it or they silently never run.
+
+**Trailing-comma support** lives in `is_parse_comma_separated_end` (`src/parser/mod.rs:~4280`). Extending the set of clauses where a trailing `,` is tolerated (FROM list, IN list, …) goes there, or in the per-clause loop's bespoke check (e.g. `parse_from_clause_body`'s Snowflake terminator set).
 
 **Prefer `WithSpan<Ident>` / `WithSpan<Expr>` in new AST fields:**
 `parse_identifier(in_table_clause)?` returns `WithSpan<Ident>`. Keep that wrapping in new AST nodes so kernel-cll lineage can surface source positions. Reach for `parse_identifier_no_span()` only when there's a specific reason not to carry the span (e.g. matching an existing surrounding type that's still plain `Ident`). For new `Expr` fields, wrap with the standard idiom: `let start_idx = self.index; let expr = self.parse_expr()?; expr.spanning(self.span_from_index(start_idx))` — see `selection` in `parse_select` for the template. `span_from_index` anchors its end at `self.index - 1` (the last consumed token), so the trailing `)` of an enclosing `(...)` is correctly excluded.
@@ -318,6 +321,10 @@ When adding fields to AST structs, you must update ALL pattern matches:
 **Recursive AST types**: New fields containing `Expr` inside `Function`/`Expr` cycle need `Box<Expr>` to break infinite size (e.g., `HavingBound(Box<Expr>)`).
 
 **`ObjectName` uses `Vec<Ident>`** not `Vec<WithSpan<Ident>>` — don't wrap idents in `WithSpan` when constructing manually.
+
+**`DECLARE` has 5 dialect-specific branches** in `parse_declare` (Snowflake block, Databricks variable+cursor, BigQuery variable-list, T-SQL `@var [AS] type [= expr]`, Postgres-style cursor). Order matters: each branch returns early; a later branch never runs if an earlier one matched. When adding a new dialect, gate by `dialect_of!` *and* by a discriminator that won't false-match the others (e.g. T-SQL gates on `name.value.starts_with('@')`, Databricks falls through to the cursor path when `peek == CURSOR`).
+
+**Variable-length type lengths** are split: `parse_optional_character_length` (used by VARCHAR / CHAR — accepts `MAX` and unit suffixes) vs `parse_optional_precision` (used by NVARCHAR / VARBINARY / TIMESTAMP / etc. — `Option<u64>`, accepts `MAX` as `None`). When a new type accepts `MAX`, pick the right helper or extend it; don't write a third one.
 
 #### Upstream Compatibility
 Since this is a fork of apache/datafusion-sqlparser-rs:

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -48,6 +48,7 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
         "--clickhouse" => Box::new(ClickHouseDialect {}),
         "--duckdb" => Box::new(DuckDbDialect {}),
         "--sqlite" => Box::new(SQLiteDialect {}),
+        "--databricks" => Box::new(sqlparser::dialect::DatabricksDialect {}),
         "--generic" | "" => Box::new(GenericDialect {}),
         s => panic!("Unexpected parameter: {s}"),
     };

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -36,21 +36,19 @@ $ cargo run --feature json_example --example cli FILENAME.sql [--dialectname]
 "#,
     );
 
-    let dialect: Box<dyn Dialect> = match std::env::args().nth(2).unwrap_or_default().as_ref() {
-        "--ansi" => Box::new(AnsiDialect {}),
-        "--bigquery" => Box::new(BigQueryDialect {}),
-        "--postgres" => Box::new(PostgreSqlDialect {}),
-        "--ms" => Box::new(MsSqlDialect {}),
-        "--mysql" => Box::new(MySqlDialect {}),
-        "--snowflake" => Box::new(SnowflakeDialect {}),
-        "--hive" => Box::new(HiveDialect {}),
-        "--redshift" => Box::new(RedshiftSqlDialect {}),
-        "--clickhouse" => Box::new(ClickHouseDialect {}),
-        "--duckdb" => Box::new(DuckDbDialect {}),
-        "--sqlite" => Box::new(SQLiteDialect {}),
-        "--databricks" => Box::new(sqlparser::dialect::DatabricksDialect {}),
-        "--generic" | "" => Box::new(GenericDialect {}),
-        s => panic!("Unexpected parameter: {s}"),
+    // Resolve the `--<name>` flag via `dialect_from_str` so every dialect the
+    // library knows about is available to single-file repros. Falls back to
+    // GenericDialect when the flag is absent or `--generic`.
+    let raw_flag = std::env::args().nth(2).unwrap_or_default();
+    let dialect: Box<dyn Dialect> = if raw_flag.is_empty() {
+        Box::new(GenericDialect {})
+    } else if let Some(name) = raw_flag.strip_prefix("--") {
+        // Backwards-compat alias: `--ms` was the original spelling for MSSQL.
+        let canonical = if name == "ms" { "mssql" } else { name };
+        sqlparser::dialect::dialect_from_str(canonical)
+            .unwrap_or_else(|| panic!("Unknown dialect: --{name}"))
+    } else {
+        panic!("Unexpected parameter: {raw_flag}")
     };
 
     println!("Parsing from file '{}' using {:?}", &filename, dialect);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2186,6 +2186,24 @@ pub enum Statement {
     /// but may also compatible with other SQL.
     Discard { object_type: DiscardObject },
     /// ```sql
+    /// IF condition THEN
+    ///   stmt; ...
+    /// [ELSEIF condition THEN
+    ///   stmt; ...]
+    /// [ELSE
+    ///   stmt; ...]
+    /// END IF
+    /// ```
+    ///
+    /// BigQuery procedural language conditional block.
+    /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#if>
+    If {
+        condition: Expr,
+        then_body: Vec<Statement>,
+        elseif_branches: Vec<IfBranch>,
+        else_body: Option<Vec<Statement>>,
+    },
+    /// ```sql
     /// SET [ SESSION | LOCAL ] ROLE role_name
     /// ```
     ///
@@ -3965,6 +3983,31 @@ impl fmt::Display for Statement {
                 if let Some(op) = option {
                     write!(f, " {op}")?;
                 }
+                Ok(())
+            }
+            Statement::If {
+                condition,
+                then_body,
+                elseif_branches,
+                else_body,
+            } => {
+                write!(f, "IF {condition} THEN")?;
+                for stmt in then_body {
+                    write!(f, " {stmt};")?;
+                }
+                for branch in elseif_branches {
+                    write!(f, " ELSEIF {} THEN", branch.condition)?;
+                    for stmt in &branch.body {
+                        write!(f, " {stmt};")?;
+                    }
+                }
+                if let Some(body) = else_body {
+                    write!(f, " ELSE")?;
+                    for stmt in body {
+                        write!(f, " {stmt};")?;
+                    }
+                }
+                write!(f, " END IF")?;
                 Ok(())
             }
             Statement::Discard { object_type } => {
@@ -6006,6 +6049,15 @@ impl fmt::Display for MergeClause {
             }
         }
     }
+}
+
+/// An ELSEIF branch in a procedural `IF` block.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct IfBranch {
+    pub condition: Expr,
+    pub body: Vec<Statement>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3249,6 +3249,18 @@ impl<'a> Parser<'a> {
                 })
             }
         } else if let Token::Word(w) = &tok.token {
+            // Postgres/Redshift bare-word postfix predicates: `expr ISNULL`
+            // and `expr NOTNULL`.
+            if w.quote_style.is_none()
+                && dialect_of!(self is PostgreSqlDialect | RedshiftSqlDialect | SQLiteDialect | GenericDialect)
+            {
+                if w.value.eq_ignore_ascii_case("ISNULL") {
+                    return Ok(Expr::IsNull(Box::new(expr)));
+                }
+                if w.value.eq_ignore_ascii_case("NOTNULL") {
+                    return Ok(Expr::IsNotNull(Box::new(expr)));
+                }
+            }
             match w.keyword {
                 Keyword::IS => {
                     if self.parse_keyword(Keyword::JSON) {
@@ -3781,6 +3793,17 @@ impl<'a> Parser<'a> {
                 _ => Ok(0),
             },
             Token::Word(w) if w.keyword == Keyword::IS => Ok(Self::IS_PREC),
+            // Postgres / Redshift accept `expr ISNULL` and `expr NOTNULL` as
+            // bare-word postfix predicates (equivalent to `IS NULL` / `IS NOT
+            // NULL`). They aren't reserved keywords; match by spelling.
+            Token::Word(w)
+                if w.quote_style.is_none()
+                    && (w.value.eq_ignore_ascii_case("ISNULL")
+                        || w.value.eq_ignore_ascii_case("NOTNULL"))
+                    && dialect_of!(self is PostgreSqlDialect | RedshiftSqlDialect | SQLiteDialect | GenericDialect) =>
+            {
+                Ok(Self::IS_PREC)
+            }
             Token::Word(w) if w.keyword == Keyword::IN => Ok(Self::BETWEEN_PREC),
             Token::Word(w) if w.keyword == Keyword::BETWEEN => Ok(Self::BETWEEN_PREC),
             Token::Word(w) if w.keyword == Keyword::LIKE => Ok(Self::LIKE_PREC),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10792,6 +10792,19 @@ impl<'a> Parser<'a> {
 
     pub fn parse_optional_precision(&mut self) -> Result<Option<u64>, ParserError> {
         if self.consume_token(&Token::LParen) {
+            // T-SQL allows `MAX` instead of an integer for NVARCHAR / VARBINARY
+            // / etc. — it represents the maximum allowed length. The current
+            // `Option<u64>` shape can't capture that; map MAX to `None` so the
+            // type parses (the lineage visitor doesn't depend on the length).
+            // https://learn.microsoft.com/en-us/sql/t-sql/data-types/nchar-and-nvarchar-transact-sql
+            if matches!(
+                self.peek_token_kind(),
+                Token::Word(w) if w.keyword == Keyword::MAX
+            ) {
+                self.next_token();
+                self.expect_token(&Token::RParen)?;
+                return Ok(None);
+            }
             let n = self.parse_literal_uint()?;
             self.expect_token(&Token::RParen)?;
             Ok(Some(n))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15796,7 +15796,35 @@ impl<'a> Parser<'a> {
 
     pub fn parse_execute(&mut self) -> Result<Statement, ParserError> {
         // ClickHouse: EXECUTE AS <user> (user impersonation)
+        // T-SQL: EXECUTE AS { CALLER | OWNER | SELF | LOGIN = 'name' | USER = 'name' }
+        // https://learn.microsoft.com/en-us/sql/t-sql/statements/execute-as-clause-transact-sql
         if self.parse_keyword(Keyword::AS) {
+            // T-SQL pattern: optional `LOGIN`/`USER` keyword followed by `= 'value'`.
+            if dialect_of!(self is MsSqlDialect | GenericDialect) {
+                if let Token::Word(w) = self.peek_token().token.clone() {
+                    let kw = w.value.to_uppercase();
+                    if matches!(kw.as_str(), "LOGIN" | "USER")
+                        && self.peek_nth_token(1).token == Token::Eq
+                    {
+                        // Consume `LOGIN =` / `USER =`.
+                        self.next_token();
+                        self.next_token();
+                        // The remainder is a string literal name; expose it
+                        // through the existing `user` Ident slot.
+                        let next = self.next_token();
+                        let user = match next.token {
+                            Token::SingleQuotedString(s)
+                            | Token::DoubleQuotedString(s)
+                            | Token::NationalStringLiteral(s) => {
+                                Ident::with_quote('\'', s).spanning(next.span)
+                            }
+                            Token::Word(w) => w.to_ident().spanning(next.span),
+                            _ => return self.expected("user/login name", next),
+                        };
+                        return Ok(Statement::ExecuteAs { user });
+                    }
+                }
+            }
             let user = self.parse_identifier(false)?;
             return Ok(Statement::ExecuteAs { user });
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -843,7 +843,7 @@ impl<'a> Parser<'a> {
                 // `PREPARE`, `EXECUTE` and `DEALLOCATE` are Postgres-specific
                 // syntaxes. They are used for Postgres prepared statement.
                 Keyword::DEALLOCATE => Ok(self.parse_deallocate()?),
-                Keyword::EXECUTE => Ok(self.parse_execute()?),
+                Keyword::EXECUTE | Keyword::EXEC => Ok(self.parse_execute()?),
                 Keyword::PREPARE => Ok(self.parse_prepare()?),
                 Keyword::MERGE => Ok(self.parse_merge()?),
                 // `PRAGMA` is sqlite specific https://www.sqlite.org/pragma.html
@@ -15973,12 +15973,62 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let name = self.parse_identifier(false)?;
+        // T-SQL: `EXEC [@return_status =] proc_name [args]` where `proc_name`
+        // is dotted (`schema.proc`) and arguments are comma-separated WITHOUT
+        // parens. https://learn.microsoft.com/en-us/sql/t-sql/language-elements/execute-transact-sql
+        // Skip the optional `@return = ` prefix; we don't surface it.
+        if dialect_of!(self is MsSqlDialect | GenericDialect) {
+            let saved = self.index;
+            let mut consumed = false;
+            if let Ok(ident_with_span) = self.parse_identifier(false) {
+                let value_starts_at = ident_with_span.unwrap().value.starts_with('@');
+                if value_starts_at && self.consume_token(&Token::Eq) {
+                    consumed = true;
+                }
+            }
+            if !consumed {
+                self.index = saved;
+            }
+        }
+
+        // First identifier of the proc name.
+        let first = self.parse_identifier(false)?;
+        // Accept dotted procedure names (T-SQL `dbo.proc`); flatten to a
+        // single Ident so the existing AST shape stays unchanged.
+        let name = if dialect_of!(self is MsSqlDialect | GenericDialect)
+            && self.peek_token_is(&Token::Period)
+        {
+            let mut buf = first.clone().unwrap().value;
+            while self.consume_token(&Token::Period) {
+                let next = self.parse_identifier(false)?.unwrap();
+                buf.push('.');
+                buf.push_str(&next.value);
+            }
+            Ident::new(buf).empty_span()
+        } else {
+            first
+        };
 
         let mut parameters = vec![];
         if self.consume_token(&Token::LParen) {
             parameters = self.parse_comma_separated(Parser::parse_expr)?;
             self.expect_token(&Token::RParen)?;
+        } else if dialect_of!(self is MsSqlDialect | GenericDialect) {
+            // T-SQL `EXEC proc arg1, arg2, ...` — bare comma-separated args.
+            // Only consume if the following token actually starts an
+            // expression so we don't swallow a `;`/EOF.
+            let next_is_terminator = match self.peek_token_kind() {
+                Token::SemiColon | Token::EOF => true,
+                Token::Word(w) => matches!(w.keyword, Keyword::INTO | Keyword::USING),
+                _ => false,
+            };
+            if !next_is_terminator {
+                if let Some(args) =
+                    self.maybe_parse(|p| p.parse_comma_separated(|p2| p2.parse_expr()))
+                {
+                    parameters = args;
+                }
+            }
         }
 
         // PostgreSQL / Trino: EXECUTE name [(params)] USING expr [AS alias] [, ...]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7762,6 +7762,20 @@ impl<'a> Parser<'a> {
                 Token::make_keyword("ENCODE"),
                 Token::make_word(&encoding.value, encoding.quote_style),
             ])))
+        } else if dialect_of!(self is RedshiftSqlDialect | GenericDialect)
+            && self.parse_keyword(Keyword::DISTKEY)
+        {
+            // Redshift inline column attribute: DISTKEY (no arguments)
+            Ok(Some(ColumnOption::DialectSpecific(vec![
+                Token::make_keyword("DISTKEY"),
+            ])))
+        } else if dialect_of!(self is RedshiftSqlDialect | GenericDialect)
+            && self.parse_keyword(Keyword::SORTKEY)
+        {
+            // Redshift inline column attribute: SORTKEY (no arguments)
+            Ok(Some(ColumnOption::DialectSpecific(vec![
+                Token::make_keyword("SORTKEY"),
+            ])))
         } else {
             Ok(None)
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10198,6 +10198,19 @@ impl<'a> Parser<'a> {
         let after_as = self.parse_keyword(Keyword::AS);
         let next_token = self.next_token();
         match next_token.token {
+            // T-SQL trailing query hint `OPTION (RECOMPILE)` — rewind so the
+            // top-level query parser can consume the `OPTION (...)` clause
+            // instead of mis-parsing it as `<table> OPTION (col_list)`.
+            // Must run BEFORE the catch-all "any identifier" arm.
+            Token::Word(w)
+                if !after_as
+                    && w.keyword == Keyword::OPTION
+                    && dialect_of!(self is MsSqlDialect | GenericDialect)
+                    && matches!(self.peek_token_kind(), Token::LParen) =>
+            {
+                self.prev_token();
+                Ok(None)
+            }
             // Accept any identifier after `AS` (though many dialects have restrictions on
             // keywords that may appear here). If there's no `AS`: don't parse keywords,
             // which may start a construct allowed in this position, to be parsed as aliases.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11427,6 +11427,15 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            // Optional `WITH TIES` after the LIMIT count (ClickHouse / BigQuery
+            // / standard SQL FETCH equivalent). The Query AST doesn't carry the
+            // tie flag, so consume-and-discard for now — round-trip won't keep
+            // it but lineage is unaffected.
+            // https://clickhouse.com/docs/sql-reference/statements/select/limit
+            if limit.is_some() {
+                let _ = self.parse_keywords(&[Keyword::WITH, Keyword::TIES]);
+            }
+
             let limit_by =
                 if dialect_of!(self is ClickHouseDialect) && self.parse_keyword(Keyword::BY) {
                     self.parse_comma_separated(Parser::parse_expr)?
@@ -11455,6 +11464,25 @@ impl<'a> Parser<'a> {
                     offset = Some(self.parse_offset()?)
                 }
             }
+            // T-SQL trailing query hint: `OPTION (RECOMPILE)` /
+            // `OPTION (FORCE ORDER, MAXDOP 4)` etc. Consume the balanced
+            // paren chunk; we don't surface it in the AST.
+            // https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query
+            if dialect_of!(self is MsSqlDialect | GenericDialect)
+                && self.parse_keyword(Keyword::OPTION)
+            {
+                self.expect_token(&Token::LParen)?;
+                let mut depth = 1i32;
+                while depth > 0 {
+                    match self.next_token().token {
+                        Token::LParen => depth += 1,
+                        Token::RParen => depth -= 1,
+                        Token::EOF => break,
+                        _ => {}
+                    }
+                }
+            }
+
             let format_clause = if dialect_of!(self is ClickHouseDialect | GenericDialect)
                 && self.parse_keyword(Keyword::FORMAT)
             {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9308,6 +9308,9 @@ impl<'a> Parser<'a> {
 
     pub fn parse_snowflake_json_path(&mut self) -> Result<Value, ParserError> {
         let mut buf = String::new();
+        // Track bracket nesting so we can ignore whitespace inside `[ ... ]`
+        // (Snowflake accepts both `v:f['k']` and `v:f[ 'k' ]`).
+        let mut bracket_depth: i32 = 0;
 
         let mut next_next_token = Some(self.next_token());
         while let Some(next_token) = next_next_token {
@@ -9331,9 +9334,15 @@ impl<'a> Parser<'a> {
                         self.prev_token();
                         break;
                     }
+                    bracket_depth += 1;
                     buf.push('[')
                 }
-                Token::RBracket => buf.push(']'),
+                Token::RBracket => {
+                    if bracket_depth > 0 {
+                        bracket_depth -= 1;
+                    }
+                    buf.push(']')
+                }
                 // Only consume * inside brackets [*] for array wildcard traversal.
                 // Bare * after . is a qualified wildcard (.* EXCEPT) not a JSON path.
                 Token::Mul if buf.ends_with('[') => buf.push('*'),
@@ -9361,6 +9370,13 @@ impl<'a> Parser<'a> {
                     buf.push(')');
                 }
                 Token::Whitespace(_) => {
+                    if bracket_depth > 0 {
+                        // Inside `[ ... ]`, whitespace is insignificant — keep scanning.
+                        // Don't append it to the path buffer; the AST normalizes
+                        // `v:f[ 'k' ]` to `v:f['k']`.
+                        next_next_token = self.next_token_no_skip().cloned();
+                        continue;
+                    }
                     break;
                 }
                 _ => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6402,12 +6402,16 @@ impl<'a> Parser<'a> {
             );
             if !is_cursor {
                 let saw_default = self.parse_keyword(Keyword::DEFAULT);
+                // Direct `= expr` initialiser (no type, no DEFAULT keyword) —
+                // Databricks supports `DECLARE name = expr;`.
+                let saw_eq = !saw_default && self.consume_token(&Token::Eq);
                 if !saw_default
+                    && !saw_eq
                     && !matches!(self.peek_token().token, Token::SemiColon | Token::EOF)
                 {
                     let _ = self.parse_data_type()?;
                 }
-                if saw_default || self.parse_keyword(Keyword::DEFAULT) {
+                if saw_eq || saw_default || self.parse_keyword(Keyword::DEFAULT) {
                     let _ = self.parse_expr()?;
                 }
                 return Ok(Statement::SetVariable {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10160,6 +10160,13 @@ impl<'a> Parser<'a> {
             {
                 Ok(Some(w.to_ident().spanning(next_token.span)))
             }
+            // VIEW is reserved only because of Hive's `LATERAL VIEW` clause
+            // (always consumed as a 2-keyword pair before we get here). When
+            // it appears in alias position alone — e.g. customer SQL with
+            // `FULL OUTER JOIN VIEWS view ON …` — it's an ordinary alias.
+            Token::Word(w) if w.keyword == Keyword::VIEW => {
+                Ok(Some(w.to_ident().spanning(next_token.span)))
+            }
             // MSSQL supports single-quoted strings as aliases for columns
             // We accept them as table aliases too, although MSSQL does not.
             //

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6816,7 +6816,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let clone = if self.parse_keyword(Keyword::CLONE) {
+        let mut clone = if self.parse_keyword(Keyword::CLONE) {
             self.parse_object_name(false).ok()
         } else {
             None
@@ -7321,8 +7321,18 @@ impl<'a> Parser<'a> {
 
         // Parse optional `AS ( query )` or `AS table_name` (ClickHouse)
         let query = if self.parse_keyword(Keyword::AS) {
-            // Check if AS is followed by a plain identifier (not a query keyword)
-            // ClickHouse: CREATE TABLE t1 (...) AS t2
+            // T-SQL / Fabric: `CREATE TABLE foo AS CLONE OF bar [AT '<ts>']`.
+            // https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-as-clone-of-transact-sql
+            // Surface the cloned source through the existing `clone` slot.
+            if self.parse_keywords(&[Keyword::CLONE, Keyword::OF]) {
+                let source = self.parse_object_name(false)?;
+                clone = Some(source);
+                // Optional `AT '<timestamp>'` time-travel suffix.
+                if self.parse_keyword(Keyword::AT) {
+                    let _ = self.parse_expr()?;
+                }
+                None
+            } else {
             match self.peek_token().token {
                 Token::Word(ref w)
                     if !matches!(
@@ -7417,6 +7427,7 @@ impl<'a> Parser<'a> {
                     }))
                 }
                 _ => Some(self.parse_boxed_query()?),
+            }
             }
         } else {
             None

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11786,7 +11786,23 @@ impl<'a> Parser<'a> {
                 None
             };
 
-        let top = if self.parse_keyword(Keyword::TOP) {
+        // `SELECT TOP n …` is MSSQL / Sybase / Snowflake / Redshift; gate so
+        // dialects that don't use it (BigQuery, Postgres, MySQL) treat `TOP`
+        // as an ordinary identifier — e.g. `SELECT TOP.col` where `TOP` is a
+        // table alias.
+        let top = if dialect_of!(self is MsSqlDialect | SnowflakeDialect | RedshiftSqlDialect | GenericDialect)
+            && matches!(
+                self.peek_token_kind(),
+                Token::Word(w) if w.keyword == Keyword::TOP
+            )
+            // Only consume TOP when followed by a number / `(` / `PERCENT` —
+            // the actual `TOP n` shape. Otherwise it's an identifier.
+            && matches!(
+                self.peek_nth_token_ref(1).token,
+                Token::Number(_, _) | Token::LParen
+            )
+            && self.parse_keyword(Keyword::TOP)
+        {
             Some(self.parse_top()?)
         } else {
             None

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6440,6 +6440,47 @@ impl<'a> Parser<'a> {
             self.index = idx;
         }
 
+        // T-SQL: DECLARE @var [AS] type [= expr] [, @var2 [AS] type [= expr]]
+        // https://learn.microsoft.com/en-us/sql/t-sql/language-elements/declare-local-variable-transact-sql
+        //
+        // Gate on the leading `@` so we don't intercept Postgres
+        // `DECLARE name BINARY CURSOR FOR …` (no `@` prefix).
+        if dialect_of!(self is MsSqlDialect | GenericDialect) && name.value.starts_with('@') {
+            let idx = self.index;
+            // T-SQL never uses the `[BINARY] [INSENSITIVE] CURSOR` shape; if
+            // the next token isn't `CURSOR`, treat the rest as a regular
+            // variable declaration list.
+            let _ = self.parse_keyword(Keyword::AS);
+            if !matches!(
+                self.peek_token_kind(),
+                Token::Word(w) if w.keyword == Keyword::CURSOR
+            ) {
+                // Parse first variable's type and optional `= <expr>`.
+                let _ = self.parse_data_type()?;
+                if self.consume_token(&Token::Eq) {
+                    let _ = self.parse_expr()?;
+                }
+                // Parse additional comma-separated declarations.
+                while self.consume_token(&Token::Comma) {
+                    let _ = self.parse_identifier(false)?;
+                    let _ = self.parse_keyword(Keyword::AS);
+                    let _ = self.parse_data_type()?;
+                    if self.consume_token(&Token::Eq) {
+                        let _ = self.parse_expr()?;
+                    }
+                }
+                return Ok(Statement::SetVariable {
+                    local: false,
+                    hivevar: false,
+                    tuple: false,
+                    variable: ObjectName(vec![name]),
+                    value: vec![],
+                    additional_assignments: vec![],
+                });
+            }
+            self.index = idx;
+        }
+
         let binary = self.parse_keyword(Keyword::BINARY);
         let sensitive = if self.parse_keyword(Keyword::INSENSITIVE) {
             Some(true)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14509,7 +14509,9 @@ impl<'a> Parser<'a> {
                 }
                 func_name
             } else {
-                self.parse_object_name(false)?
+                // BigQuery hyphenated project IDs (`my-proj.ds.tbl`) are unlocked
+                // by the `in_table_clause` flag on `parse_identifier`.
+                self.parse_object_name(true)?
             };
             let is_mysql = dialect_of!(self is MySqlDialect);
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10211,6 +10211,21 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 Ok(None)
             }
+            // MySQL / MariaDB / Snowflake index hints: `USE / IGNORE / FORCE
+            // INDEX (...)`. Don't consume the `USE / IGNORE / FORCE` as a
+            // table alias — leave them for the trailing-hint loop in
+            // `parse_table_and_joins`.
+            Token::Word(w)
+                if !after_as
+                    && matches!(w.keyword, Keyword::USE | Keyword::IGNORE | Keyword::FORCE)
+                    && matches!(
+                        self.peek_token_kind(),
+                        Token::Word(next) if next.keyword == Keyword::INDEX || next.keyword == Keyword::KEY
+                    ) =>
+            {
+                self.prev_token();
+                Ok(None)
+            }
             // Accept any identifier after `AS` (though many dialects have restrictions on
             // keywords that may appear here). If there's no `AS`: don't parse keywords,
             // which may start a construct allowed in this position, to be parsed as aliases.
@@ -12710,6 +12725,50 @@ impl<'a> Parser<'a> {
             && self.parse_keyword(Keyword::AT)
         {
             let _ = self.parse_identifier(false)?;
+        }
+
+        // MySQL / MariaDB / Snowflake index hints:
+        //   tbl [AS alias] { USE | IGNORE | FORCE } [INDEX|KEY] [FOR {JOIN|...}] (idx, ...)
+        // Consume the balanced paren chunk; we don't surface index hints in
+        // the AST.
+        // https://dev.mysql.com/doc/refman/8.4/en/index-hints.html
+        loop {
+            let hint_kw = match self.peek_token_kind() {
+                Token::Word(w)
+                    if matches!(w.keyword, Keyword::USE | Keyword::IGNORE | Keyword::FORCE) =>
+                {
+                    Some(w.keyword)
+                }
+                _ => None,
+            };
+            let Some(kw) = hint_kw else { break };
+            // Need to look further: must be followed by INDEX or KEY.
+            let is_index_hint = matches!(
+                self.peek_nth_token_ref(1).token,
+                Token::Word(ref w) if w.keyword == Keyword::INDEX || w.keyword == Keyword::KEY
+            );
+            if !is_index_hint {
+                break;
+            }
+            // Consume `USE/IGNORE/FORCE` + `INDEX|KEY`.
+            self.next_token();
+            self.next_token();
+            // Optional `FOR { JOIN | ORDER BY | GROUP BY }`.
+            if self.parse_keyword(Keyword::FOR) {
+                let _ = self.parse_one_of_keywords(&[
+                    Keyword::JOIN,
+                    Keyword::ORDER,
+                    Keyword::GROUP,
+                ]);
+                let _ = self.parse_keyword(Keyword::BY);
+            }
+            // Required `(name [, name]*)` — empty list also accepted.
+            self.expect_token(&Token::LParen)?;
+            if !self.consume_token(&Token::RParen) {
+                let _ = self.parse_comma_separated(|p| p.parse_identifier(false))?;
+                self.expect_token(&Token::RParen)?;
+            }
+            let _ = kw; // kw discarded; preserved name not needed in AST.
         }
         // Note that for keywords to be properly handled here, they need to be
         // added to `RESERVED_FOR_TABLE_ALIAS`, otherwise they may be parsed as

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6384,27 +6384,42 @@ impl<'a> Parser<'a> {
         }
 
         // Databricks: DECLARE [OR REPLACE] [VARIABLE] name [type] [DEFAULT expr]
+        //   — variable declaration. Falls through to the cursor path when the
+        //   syntax is `DECLARE name CURSOR FOR <query>` instead.
         // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-aux-var-declare.html
+        // https://docs.databricks.com/aws/en/sql/language-manual/control-flow/declare-cursor-stmt
         if dialect_of!(self is DatabricksDialect) {
+            let saved = self.index;
             let _ = self.parse_keywords(&[Keyword::OR, Keyword::REPLACE]);
             let _ = self.parse_keyword(Keyword::VARIABLE);
             let name = self.parse_identifier(false)?.unwrap();
-            // Optional data type (DEFAULT may follow directly without a type)
-            let saw_default = self.parse_keyword(Keyword::DEFAULT);
-            if !saw_default && !matches!(self.peek_token().token, Token::SemiColon | Token::EOF) {
-                let _ = self.parse_data_type()?;
+            // If next is CURSOR, this is the cursor form — rewind and fall
+            // through to the standard `[BINARY] [INSENSITIVE] CURSOR FOR …`
+            // path below.
+            let is_cursor = matches!(
+                self.peek_token_kind(),
+                Token::Word(w) if w.keyword == Keyword::CURSOR
+            );
+            if !is_cursor {
+                let saw_default = self.parse_keyword(Keyword::DEFAULT);
+                if !saw_default
+                    && !matches!(self.peek_token().token, Token::SemiColon | Token::EOF)
+                {
+                    let _ = self.parse_data_type()?;
+                }
+                if saw_default || self.parse_keyword(Keyword::DEFAULT) {
+                    let _ = self.parse_expr()?;
+                }
+                return Ok(Statement::SetVariable {
+                    local: false,
+                    hivevar: false,
+                    tuple: false,
+                    variable: ObjectName(vec![name]),
+                    value: vec![],
+                    additional_assignments: vec![],
+                });
             }
-            if saw_default || self.parse_keyword(Keyword::DEFAULT) {
-                let _ = self.parse_expr()?;
-            }
-            return Ok(Statement::SetVariable {
-                local: false,
-                hivevar: false,
-                tuple: false,
-                variable: ObjectName(vec![name]),
-                value: vec![],
-                additional_assignments: vec![],
-            });
+            self.index = saved;
         }
 
         let name = self.parse_identifier(false)?.unwrap();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10046,8 +10046,13 @@ impl<'a> Parser<'a> {
         }?;
 
         // Parse array data types. Note: this is postgresql-specific and different from
-        // Keyword::ARRAY syntax from above
-        while self.consume_token(&Token::LBracket) {
+        // Keyword::ARRAY syntax from above. Only `[]` (empty brackets) belongs
+        // to the type — `[N]` is an array subscript and stays for the outer
+        // expression parser, e.g. `v::array[0]` in Snowflake variant access.
+        while self.peek_token_is(&Token::LBracket)
+            && matches!(self.peek_nth_token_ref(1).token, Token::RBracket)
+        {
+            self.expect_token(&Token::LBracket)?;
             self.expect_token(&Token::RBracket)?;
             data = DataType::Array(ArrayElemTypeDef::SquareBracket(Box::new(data)))
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -607,8 +607,24 @@ impl<'a> Parser<'a> {
         let mut expecting_statement_delimiter = false;
         loop {
             // ignore empty statements (between successive statement delimiters)
-            while self.consume_token(&Token::SemiColon) {
-                expecting_statement_delimiter = false;
+            // and MS-SQL `GO` batch separators (sqlcmd / SSMS); they're not
+            // SQL statements but show up in script files.
+            loop {
+                if self.consume_token(&Token::SemiColon) {
+                    expecting_statement_delimiter = false;
+                    continue;
+                }
+                if dialect_of!(self is MsSqlDialect | GenericDialect)
+                    && matches!(
+                        self.peek_token_kind(),
+                        Token::Word(w) if w.value.eq_ignore_ascii_case("GO") && w.quote_style.is_none()
+                    )
+                {
+                    self.next_token();
+                    expecting_statement_delimiter = false;
+                    continue;
+                }
+                break;
             }
 
             match self.peek_token_kind().clone() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6306,23 +6306,13 @@ impl<'a> Parser<'a> {
 
     /// Parse the body of an `IF`/`ELSEIF`/`ELSE` block: a sequence of
     /// statements terminated by `;`, stopping at `ELSEIF`, `ELSE`, or `END`.
+    /// Each statement must be terminated by `;` to match Display's output and
+    /// keep round-trips idempotent for `verified_stmt`.
     fn parse_if_body(&mut self) -> Result<Vec<Statement>, ParserError> {
         let mut stmts = Vec::new();
         loop {
-            match self.peek_token_kind() {
-                Token::Word(w)
-                    if w.keyword == Keyword::END
-                        || w.keyword == Keyword::ELSE
-                        || w.value.eq_ignore_ascii_case("ELSEIF") =>
-                {
-                    break;
-                }
-                Token::EOF => break,
-                _ => {}
-            }
-            // Skip stray separators.
+            // Skip stray leading separators (e.g. `;;`).
             while self.consume_token(&Token::SemiColon) {}
-            // Re-check after consuming separators.
             match self.peek_token_kind() {
                 Token::Word(w)
                     if w.keyword == Keyword::END
@@ -6335,8 +6325,8 @@ impl<'a> Parser<'a> {
                 _ => {}
             }
             stmts.push(self.parse_statement()?);
-            // Optional terminator after each statement.
-            let _ = self.consume_token(&Token::SemiColon);
+            // Each body statement must be `;`-terminated.
+            self.expect_token(&Token::SemiColon)?;
         }
         Ok(stmts)
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12512,10 +12512,12 @@ impl<'a> Parser<'a> {
             // Snowflake allows trailing commas in FROM clause
             // e.g. `SELECT * FROM t1, lateral flatten(...) alias, WHERE ...`
             // https://docs.snowflake.com/en/release-notes/2024/8_11#select-supports-trailing-commas
-            // Check if the comma was trailing (followed by a clause keyword)
+            // Check if the comma was trailing (followed by a clause keyword,
+            // closing paren / brace, or end-of-statement).
             if dialect_of!(self is SnowflakeDialect) {
-                if let Token::Word(w) = self.peek_token_kind().clone() {
-                    if matches!(
+                let next = self.peek_token_kind().clone();
+                let trailing = match &next {
+                    Token::Word(w) => matches!(
                         w.keyword,
                         Keyword::WHERE
                             | Keyword::GROUP
@@ -12529,10 +12531,12 @@ impl<'a> Parser<'a> {
                             | Keyword::FETCH
                             | Keyword::OFFSET
                             | Keyword::WINDOW
-                    ) {
-                        // Trailing comma - stop parsing FROM clause
-                        break;
-                    }
+                    ),
+                    Token::RParen | Token::SemiColon | Token::EOF => true,
+                    _ => false,
+                };
+                if trailing {
+                    break;
                 }
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9308,9 +9308,6 @@ impl<'a> Parser<'a> {
 
     pub fn parse_snowflake_json_path(&mut self) -> Result<Value, ParserError> {
         let mut buf = String::new();
-        // Track bracket nesting so we can ignore whitespace inside `[ ... ]`
-        // (Snowflake accepts both `v:f['k']` and `v:f[ 'k' ]`).
-        let mut bracket_depth: i32 = 0;
 
         let mut next_next_token = Some(self.next_token());
         while let Some(next_token) = next_next_token {
@@ -9334,15 +9331,63 @@ impl<'a> Parser<'a> {
                         self.prev_token();
                         break;
                     }
-                    bracket_depth += 1;
-                    buf.push('[')
-                }
-                Token::RBracket => {
-                    if bracket_depth > 0 {
-                        bracket_depth -= 1;
+                    // Snowflake `obj[<expr>]` — `<expr>` can be a literal, integer,
+                    // or any expression (including nested function calls and `:` paths).
+                    // Consume balanced brackets/parens as a single opaque chunk so
+                    // arbitrary index expressions don't terminate the path early.
+                    buf.push('[');
+                    let mut bracket_depth = 1i32;
+                    let mut paren_depth = 0i32;
+                    loop {
+                        let t = self.next_token().token;
+                        match t {
+                            Token::EOF => break,
+                            Token::LBracket => {
+                                bracket_depth += 1;
+                                buf.push('[');
+                            }
+                            Token::RBracket => {
+                                if paren_depth == 0 {
+                                    bracket_depth -= 1;
+                                    buf.push(']');
+                                    if bracket_depth == 0 {
+                                        break;
+                                    }
+                                } else {
+                                    buf.push(']');
+                                }
+                            }
+                            Token::LParen => {
+                                paren_depth += 1;
+                                buf.push('(');
+                            }
+                            Token::RParen => {
+                                paren_depth -= 1;
+                                buf.push(')');
+                            }
+                            Token::Word(ref w) if w.quote_style == Some('`') => {
+                                write!(buf, "`{}`", w.value).unwrap()
+                            }
+                            Token::Word(w) => buf.push_str(&w.value),
+                            Token::Number(n, _) => buf.push_str(&n),
+                            Token::SingleQuotedString(s) => write!(buf, "'{}'", s).unwrap(),
+                            Token::DoubleQuotedString(s) => write!(buf, "\"{}\"", s).unwrap(),
+                            Token::Period => buf.push('.'),
+                            Token::Comma => buf.push(','),
+                            Token::Colon => buf.push(':'),
+                            Token::Minus => buf.push('-'),
+                            Token::Plus => buf.push('+'),
+                            Token::Mul => buf.push('*'),
+                            Token::Div => buf.push('/'),
+                            Token::Whitespace(_) => {}
+                            _ => {}
+                        }
                     }
-                    buf.push(']')
                 }
+                // Stray `]` (no matching `[`) — consumed for back-compat with
+                // upstream callers (e.g. `parse_map_access` is lenient about
+                // missing closing brackets when the path ate one).
+                Token::RBracket => buf.push(']'),
                 // Only consume * inside brackets [*] for array wildcard traversal.
                 // Bare * after . is a qualified wildcard (.* EXCEPT) not a JSON path.
                 Token::Mul if buf.ends_with('[') => buf.push('*'),
@@ -9369,16 +9414,7 @@ impl<'a> Parser<'a> {
                     }
                     buf.push(')');
                 }
-                Token::Whitespace(_) => {
-                    if bracket_depth > 0 {
-                        // Inside `[ ... ]`, whitespace is insignificant — keep scanning.
-                        // Don't append it to the path buffer; the AST normalizes
-                        // `v:f[ 'k' ]` to `v:f['k']`.
-                        next_next_token = self.next_token_no_skip().cloned();
-                        continue;
-                    }
-                    break;
-                }
+                Token::Whitespace(_) => break,
                 _ => {
                     self.prev_token();
                     break;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -694,6 +694,10 @@ impl<'a> Parser<'a> {
                 Keyword::DROP => Ok(self.parse_drop()?),
                 Keyword::DISCARD => Ok(self.parse_discard()?),
                 Keyword::DECLARE => Ok(self.parse_declare()?),
+                // Procedural `IF cond THEN ... END IF` (BigQuery, Snowflake,
+                // MySQL, etc.). T-SQL uses `IF cond <stmt>` without THEN — fall
+                // back to the default error path so we don't claim those.
+                Keyword::IF if self.if_then_block_lookahead() => Ok(self.parse_if_statement()?),
                 Keyword::FETCH => Ok(self.parse_fetch_statement()?),
                 Keyword::DELETE => Ok(self.parse_delete()?),
                 Keyword::INSERT => Ok(self.parse_insert()?),
@@ -6220,6 +6224,121 @@ impl<'a> Parser<'a> {
         };
 
         Ok(DropFunctionDesc { name, args })
+    }
+
+    /// Look ahead from a just-consumed `IF` to decide whether this is the
+    /// procedural `IF cond THEN ... END IF` block (BigQuery / Snowflake /
+    /// MySQL / Postgres) rather than T-SQL's `IF cond <stmt>` form. We scan
+    /// the rest of the statement up to the next `;` or EOF and accept the
+    /// procedural form only if a `THEN` keyword appears at paren depth 0.
+    fn if_then_block_lookahead(&self) -> bool {
+        let mut idx = self.index;
+        let mut depth: i32 = 0;
+        loop {
+            let tok = match self.tokens.get(idx) {
+                Some(t) => &t.token,
+                None => return false,
+            };
+            match tok {
+                Token::EOF | Token::SemiColon if depth == 0 => return false,
+                Token::LParen => depth += 1,
+                Token::RParen => {
+                    if depth > 0 {
+                        depth -= 1;
+                    }
+                }
+                Token::Word(w) if depth == 0 && w.keyword == Keyword::THEN => return true,
+                _ => {}
+            }
+            idx += 1;
+        }
+    }
+
+    /// Parse a procedural `IF` block. The `IF` keyword has already been
+    /// consumed by `parse_statement`.
+    ///
+    /// ```sql
+    /// IF cond THEN stmt; [stmt;]*
+    /// [ELSEIF cond THEN stmt; [stmt;]*]*
+    /// [ELSE stmt; [stmt;]*]
+    /// END IF
+    /// ```
+    ///
+    /// BigQuery scripting; also accepted as a generic procedural construct.
+    /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#if>
+    pub fn parse_if_statement(&mut self) -> Result<Statement, ParserError> {
+        let condition = self.parse_expr()?;
+        self.expect_keyword(Keyword::THEN)?;
+        let then_body = self.parse_if_body()?;
+
+        let mut elseif_branches = vec![];
+        // ELSEIF is not a keyword in this parser; match by spelling.
+        while matches!(
+            self.peek_token_kind(),
+            Token::Word(w) if w.value.eq_ignore_ascii_case("ELSEIF")
+        ) {
+            self.next_token();
+            let cond = self.parse_expr()?;
+            self.expect_keyword(Keyword::THEN)?;
+            let body = self.parse_if_body()?;
+            elseif_branches.push(IfBranch {
+                condition: cond,
+                body,
+            });
+        }
+
+        let else_body = if self.parse_keyword(Keyword::ELSE) {
+            Some(self.parse_if_body()?)
+        } else {
+            None
+        };
+
+        self.expect_keyword(Keyword::END)?;
+        self.expect_keyword(Keyword::IF)?;
+
+        Ok(Statement::If {
+            condition,
+            then_body,
+            elseif_branches,
+            else_body,
+        })
+    }
+
+    /// Parse the body of an `IF`/`ELSEIF`/`ELSE` block: a sequence of
+    /// statements terminated by `;`, stopping at `ELSEIF`, `ELSE`, or `END`.
+    fn parse_if_body(&mut self) -> Result<Vec<Statement>, ParserError> {
+        let mut stmts = Vec::new();
+        loop {
+            match self.peek_token_kind() {
+                Token::Word(w)
+                    if w.keyword == Keyword::END
+                        || w.keyword == Keyword::ELSE
+                        || w.value.eq_ignore_ascii_case("ELSEIF") =>
+                {
+                    break;
+                }
+                Token::EOF => break,
+                _ => {}
+            }
+            // Skip stray separators.
+            while self.consume_token(&Token::SemiColon) {}
+            // Re-check after consuming separators.
+            match self.peek_token_kind() {
+                Token::Word(w)
+                    if w.keyword == Keyword::END
+                        || w.keyword == Keyword::ELSE
+                        || w.value.eq_ignore_ascii_case("ELSEIF") =>
+                {
+                    break;
+                }
+                Token::EOF => break,
+                _ => {}
+            }
+            stmts.push(self.parse_statement()?);
+            // Optional terminator after each statement.
+            let _ = self.consume_token(&Token::SemiColon);
+        }
+        Ok(stmts)
     }
 
     /// ```sql

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1240,6 +1240,7 @@ impl<'a> Tokenizer<'a> {
                                     || ch == '~'
                                     || ch == '%'
                                     || ch == '.'
+                                    || ch == '-'
                             }));
                             Ok(Some(Token::make_word(&s, None)))
                         }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2411,10 +2411,22 @@ fn test_bigquery_offset_in_arithmetic_projection() {
 fn test_bigquery_if_then_else_block() {
     // BigQuery procedural language: IF / ELSEIF / ELSE / END IF.
     // https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#if
+    //
+    // Per the docs, a `sql_statement_list` is "a list of zero or more SQL
+    // statements ending with semicolons" — so `;` is a terminator after each
+    // body statement, and an empty body is allowed.
     bigquery().verified_stmt("IF a = 1 THEN SELECT 1; END IF");
     bigquery().verified_stmt("IF a = 1 THEN SELECT 1; ELSE SELECT 2; END IF");
     bigquery()
         .verified_stmt("IF a = 1 THEN SELECT 1; ELSEIF a = 2 THEN SELECT 2; ELSE SELECT 3; END IF");
+    // Empty bodies (zero statements) are valid per the docs.
+    bigquery().verified_stmt("IF a = 1 THEN END IF");
+    bigquery().verified_stmt("IF a = 1 THEN ELSE SELECT 2; END IF");
+    // Missing `;` terminator must fail (matches the spec, keeps Display
+    // round-tripping idempotent).
+    assert!(bigquery()
+        .parse_sql_statements("IF a = 1 THEN SELECT 1 END IF")
+        .is_err());
 }
 
 #[test]

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2378,6 +2378,18 @@ fn test_bigquery_hyphenated_project_id_with_numeric_segment() {
 }
 
 #[test]
+fn test_bigquery_top_as_identifier() {
+    // BigQuery doesn't support `SELECT TOP n` (T-SQL); `TOP` should parse as
+    // an ordinary identifier — table alias, column name, etc.
+    bigquery()
+        .parse_sql_statements("SELECT TOP.col FROM tbl AS TOP")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements("SELECT TOP FROM tbl")
+        .unwrap();
+}
+
+#[test]
 fn test_bigquery_hyphenated_project_id_in_insert() {
     // BigQuery hyphenated project IDs are valid in `INSERT INTO`, not just
     // in `FROM` / table clauses.

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2396,6 +2396,16 @@ fn test_bigquery_offset_in_arithmetic_projection() {
 }
 
 #[test]
+fn test_bigquery_if_then_else_block() {
+    // BigQuery procedural language: IF / ELSEIF / ELSE / END IF.
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#if
+    bigquery().verified_stmt("IF a = 1 THEN SELECT 1; END IF");
+    bigquery().verified_stmt("IF a = 1 THEN SELECT 1; ELSE SELECT 2; END IF");
+    bigquery()
+        .verified_stmt("IF a = 1 THEN SELECT 1; ELSEIF a = 2 THEN SELECT 2; ELSE SELECT 3; END IF");
+}
+
+#[test]
 fn test_bigquery_raw_string_escaped_quote() {
     // BigQuery raw string literals preserve backslashes literally, but
     // `\'` (or `\"`) is a two-character sequence that does not terminate

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2378,6 +2378,18 @@ fn test_bigquery_hyphenated_project_id_with_numeric_segment() {
 }
 
 #[test]
+fn test_bigquery_hyphenated_project_id_in_insert() {
+    // BigQuery hyphenated project IDs are valid in `INSERT INTO`, not just
+    // in `FROM` / table clauses.
+    bigquery()
+        .parse_sql_statements("INSERT INTO my-proj.ds.tbl SELECT 1")
+        .unwrap();
+    bigquery()
+        .parse_sql_statements("INSERT INTO root-rarity-166622.scores.ds VALUES (1)")
+        .unwrap();
+}
+
+#[test]
 fn test_bigquery_offset_in_arithmetic_projection() {
     // BigQuery `WITH OFFSET` exposes `offset` as a column the projection
     // can use. Ensure trailing-comma handling still parses

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -232,6 +232,21 @@ fn parse_mssql_top() {
 }
 
 #[test]
+fn parse_mssql_go_batch_separator() {
+    // T-SQL `GO` is a sqlcmd / SSMS batch separator, not a SQL keyword.
+    // After the previous statement is `;`-terminated, the parser must
+    // skip `GO` rather than demanding another delimiter.
+    // https://learn.microsoft.com/en-us/sql/t-sql/language-elements/sql-server-utilities-statements-go
+    let stmts = ms()
+        .parse_sql_statements("SELECT 1; GO SELECT 2; GO")
+        .unwrap();
+    assert_eq!(stmts.len(), 2);
+    // Trailing `GO` alone after a `;`-terminated statement.
+    let stmts = ms().parse_sql_statements("SELECT 1; GO").unwrap();
+    assert_eq!(stmts.len(), 1);
+}
+
+#[test]
 fn parse_mssql_bin_literal() {
     let _ = ms_and_generic().one_statement_parses_to("SELECT 0xdeadBEEF", "SELECT X'deadBEEF'");
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -673,3 +673,13 @@ fn parse_mssql_exec_statement() {
     ms().parse_sql_statements("EXEC @return_status = checkstate '2'")
         .unwrap();
 }
+
+#[test]
+fn parse_mssql_execute_as_login() {
+    // T-SQL EXECUTE AS supports `LOGIN = '...'` / `USER = '...'` forms in
+    // addition to the bare CALLER / OWNER / SELF / `<name>` shapes.
+    // https://learn.microsoft.com/en-us/sql/t-sql/statements/execute-as-clause-transact-sql
+    ms().parse_sql_statements("EXECUTE AS LOGIN = 'foo'").unwrap();
+    ms().parse_sql_statements("EXECUTE AS USER = 'bar'").unwrap();
+    ms().parse_sql_statements("EXECUTE AS CALLER").unwrap();
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -647,3 +647,15 @@ fn ms_and_generic() -> TestedDialects {
         options: None,
     }
 }
+
+#[test]
+fn parse_mssql_varchar_max() {
+    // T-SQL allows `MAX` instead of an integer for variable-length types.
+    // https://learn.microsoft.com/en-us/sql/t-sql/data-types/nchar-and-nvarchar-transact-sql
+    ms().parse_sql_statements("DECLARE @x NVARCHAR(MAX)").unwrap();
+    ms().parse_sql_statements("DECLARE @x VARBINARY(MAX)").unwrap();
+    // Lowercase `max` should also work.
+    ms().parse_sql_statements("DECLARE @x NVARCHAR(max)").unwrap();
+    // Numeric precision still works.
+    ms().parse_sql_statements("DECLARE @x NVARCHAR(50)").unwrap();
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -232,6 +232,24 @@ fn parse_mssql_top() {
 }
 
 #[test]
+fn parse_mssql_declare_variable() {
+    // T-SQL `DECLARE @var [AS] type [= expr] [, @var2 type ...]`
+    // https://learn.microsoft.com/en-us/sql/t-sql/language-elements/declare-local-variable-transact-sql
+    ms().parse_sql_statements("DECLARE @x INT").unwrap();
+    ms().parse_sql_statements("DECLARE @x AS INT").unwrap();
+    ms().parse_sql_statements("DECLARE @x INT = 5").unwrap();
+    ms().parse_sql_statements("DECLARE @CheckDate AS DATETIME = GETDATE()")
+        .unwrap();
+    ms().parse_sql_statements(
+        "DECLARE @x INT, @y VARCHAR(50), @z DATETIME = GETDATE()",
+    )
+    .unwrap();
+    // Cursor declarations (no `@` prefix) keep the existing path.
+    ms().parse_sql_statements("DECLARE c CURSOR FOR SELECT 1")
+        .unwrap();
+}
+
+#[test]
 fn parse_mssql_go_batch_separator() {
     // T-SQL `GO` is a sqlcmd / SSMS batch separator, not a SQL keyword.
     // After the previous statement is `;`-terminated, the parser must

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -696,3 +696,14 @@ fn parse_mssql_create_table_as_clone_of() {
     )
     .unwrap();
 }
+
+#[test]
+fn parse_mssql_option_query_hint() {
+    // T-SQL trailing `OPTION (...)` query hint, e.g. `OPTION (RECOMPILE)`,
+    // `OPTION (FORCE ORDER, MAXDOP 4)`. Consume-and-discard.
+    // https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query
+    ms().parse_sql_statements("SELECT * FROM t WHERE c > 5 OPTION (RECOMPILE)")
+        .unwrap();
+    ms().parse_sql_statements("SELECT * FROM t OPTION (FORCE ORDER, MAXDOP 4)")
+        .unwrap();
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -659,3 +659,17 @@ fn parse_mssql_varchar_max() {
     // Numeric precision still works.
     ms().parse_sql_statements("DECLARE @x NVARCHAR(50)").unwrap();
 }
+
+#[test]
+fn parse_mssql_exec_statement() {
+    // T-SQL `EXEC` (alias of EXECUTE) supports dotted procedure names,
+    // bare comma-separated arguments (no parens), and an optional
+    // `@var = ` return-status assignment.
+    // https://learn.microsoft.com/en-us/sql/t-sql/language-elements/execute-transact-sql
+    ms().parse_sql_statements("EXEC sp_help").unwrap();
+    ms().parse_sql_statements("EXEC dbo.uspGetWhere @x").unwrap();
+    ms().parse_sql_statements("EXEC dbo.uspGetWhereUsedProductID 819, @CheckDate")
+        .unwrap();
+    ms().parse_sql_statements("EXEC @return_status = checkstate '2'")
+        .unwrap();
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -683,3 +683,16 @@ fn parse_mssql_execute_as_login() {
     ms().parse_sql_statements("EXECUTE AS USER = 'bar'").unwrap();
     ms().parse_sql_statements("EXECUTE AS CALLER").unwrap();
 }
+
+#[test]
+fn parse_mssql_create_table_as_clone_of() {
+    // T-SQL / Fabric: `CREATE TABLE foo AS CLONE OF bar [AT '<timestamp>']`
+    // — clone an existing table (optionally at a specific point in time).
+    // https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-as-clone-of-transact-sql
+    ms().parse_sql_statements("CREATE TABLE dbo.Foo AS CLONE OF dbo.Bar")
+        .unwrap();
+    ms().parse_sql_statements(
+        "CREATE TABLE dbo.Foo AS CLONE OF dbo.Bar AT '2023-05-23T14:24:10.325'",
+    )
+    .unwrap();
+}

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2060,3 +2060,20 @@ fn parse_straight_join() {
     mysql_and_generic().verified_stmt("SELECT e.* FROM e STRAIGHT_JOIN p ON e.x = p.y");
     mysql_and_generic().verified_stmt("SELECT * FROM t1 STRAIGHT_JOIN t2 ON t1.id = t2.id");
 }
+#[test]
+fn parse_mysql_index_hints() {
+    // MySQL / MariaDB index hints: `USE | IGNORE | FORCE INDEX [FOR ...] (...)`
+    // https://dev.mysql.com/doc/refman/8.4/en/index-hints.html
+    mysql()
+        .parse_sql_statements("SELECT * FROM t USE INDEX (idx)")
+        .unwrap();
+    mysql()
+        .parse_sql_statements("SELECT * FROM t AS x USE INDEX (i1, i2) JOIN y ON 1 = 1")
+        .unwrap();
+    mysql()
+        .parse_sql_statements("SELECT * FROM t IGNORE INDEX FOR JOIN (idx)")
+        .unwrap();
+    mysql()
+        .parse_sql_statements("SELECT * FROM t FORCE INDEX (idx)")
+        .unwrap();
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -628,6 +628,21 @@ fn test_redshift_array_subscript_compound_index() {
 }
 
 #[test]
+fn test_redshift_postfix_isnull_notnull() {
+    // Redshift / Postgres accept `expr ISNULL` and `expr NOTNULL` as
+    // bare-word postfix predicates (equivalent to `IS NULL` / `IS NOT NULL`).
+    // https://www.postgresql.org/docs/current/functions-comparison.html
+    redshift().one_statement_parses_to(
+        "SELECT a FROM t WHERE a NOTNULL",
+        "SELECT a FROM t WHERE a IS NOT NULL",
+    );
+    redshift().one_statement_parses_to(
+        "SELECT a FROM t WHERE a ISNULL",
+        "SELECT a FROM t WHERE a IS NULL",
+    );
+}
+
+#[test]
 fn test_redshift_extract_custom_date_parts() {
     // Redshift supports abbreviated date/time parts as identifiers
     // e.g. EXTRACT(d FROM ...) for day, EXTRACT(h FROM ...) for hour, etc.

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -435,6 +435,15 @@ fn test_distribution_styles() {
 }
 
 #[test]
+fn test_inline_distkey_sortkey_column_attributes() {
+    // Redshift allows DISTKEY and SORTKEY as inline column attributes (no parens).
+    // https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    redshift().verified_stmt(
+        "CREATE TABLE t (id VARCHAR(10) NOT NULL DISTKEY PRIMARY KEY, ts TIMESTAMP SORTKEY)",
+    );
+}
+
+#[test]
 fn test_extract_with_string_date_part() {
     // Redshift allows date parts as string literals in EXTRACT
     let sql = "SELECT EXTRACT('hour' FROM col) FROM tbl";

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1561,10 +1561,7 @@ fn parse_variant_path_with_whitespace_in_brackets() {
         "SELECT v:custom_attributes[ 'k' ]::string FROM t",
         "SELECT CAST(v:custom_attributes['k'] AS STRING) FROM t",
     );
-    snowflake().one_statement_parses_to(
-        "SELECT v:f[ 0 ] FROM t",
-        "SELECT v:f[0] FROM t",
-    );
+    snowflake().one_statement_parses_to("SELECT v:f[ 0 ] FROM t", "SELECT v:f[0] FROM t");
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1357,6 +1357,7 @@ fn test_snowflake_stage_object_names() {
         "@namespace.%table_name/path",
         "@namespace.stage_name/path",
         "@~/path",
+        "@stage/path-with-dashes/file",
     ];
     let mut allowed_object_names = vec![
         ObjectName(vec![Ident::new("my_company"), Ident::new("emp_basic")]),
@@ -1364,6 +1365,7 @@ fn test_snowflake_stage_object_names() {
         ObjectName(vec![Ident::new("@namespace.%table_name/path")]),
         ObjectName(vec![Ident::new("@namespace.stage_name/path")]),
         ObjectName(vec![Ident::new("@~/path")]),
+        ObjectName(vec![Ident::new("@stage/path-with-dashes/file")]),
     ];
 
     for it in allowed_formatted_names

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1554,6 +1554,20 @@ fn parse_object_constants_expr() {
 }
 
 #[test]
+fn parse_variant_path_with_whitespace_in_brackets() {
+    // Snowflake accepts whitespace inside `[ ... ]` after a `:` colon-path,
+    // e.g. `v:custom_attributes[ 'k' ]::string`.
+    snowflake().one_statement_parses_to(
+        "SELECT v:custom_attributes[ 'k' ]::string FROM t",
+        "SELECT CAST(v:custom_attributes['k'] AS STRING) FROM t",
+    );
+    snowflake().one_statement_parses_to(
+        "SELECT v:f[ 0 ] FROM t",
+        "SELECT v:f[0] FROM t",
+    );
+}
+
+#[test]
 fn parse_array_index_json_dot() {
     let stmt = snowflake().verified_only_select("SELECT src[0].order_number FROM car_sales");
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1596,6 +1596,23 @@ fn parse_array_index_json_with_cast() {
 }
 
 #[test]
+fn parse_view_as_table_alias() {
+    // `VIEW` is reserved only because of Hive's `LATERAL VIEW` clause, which
+    // is always consumed as a two-keyword pair. When `VIEW` appears in plain
+    // alias position it should be treated as an ordinary identifier — e.g.
+    // `FROM tbl VIEW` or `JOIN tbl AS VIEW`.
+    snowflake().verified_stmt("SELECT VIEW.x FROM t AS VIEW");
+    snowflake().one_statement_parses_to(
+        "SELECT * FROM t VIEW",
+        "SELECT * FROM t AS VIEW",
+    );
+    snowflake().one_statement_parses_to(
+        "SELECT VIEW.x FROM tbl FULL OUTER JOIN tbl2 AS VIEW ON tbl.id = VIEW.id",
+        "SELECT VIEW.x FROM tbl FULL JOIN tbl2 AS VIEW ON tbl.id = VIEW.id",
+    );
+}
+
+#[test]
 fn parse_array_subscript_after_cast() {
     // Snowflake variant access often casts a path to ARRAY then indexes the
     // result, e.g. `v:category::array[0]`. The `[N]` is an array subscript,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1861,6 +1861,13 @@ fn test_sf_trailing_commas_in_from_clause() {
         r#"SELECT a, b FROM t, LATERAL FLATTEN(INPUT => t.arr) AS f, WHERE a IS NOT NULL"#,
         r#"SELECT a, b FROM t, LATERAL FLATTEN(INPUT => t.arr) AS f WHERE a IS NOT NULL"#,
     );
+
+    // Trailing comma right before the close of an enclosing CTE / subquery
+    // (no clause keyword follows).
+    snowflake().one_statement_parses_to(
+        "WITH x AS (SELECT a FROM t1, LATERAL FLATTEN(INPUT => t1.arr),) SELECT * FROM x",
+        "WITH x AS (SELECT a FROM t1, LATERAL FLATTEN(INPUT => t1.arr)) SELECT * FROM x",
+    );
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1596,6 +1596,21 @@ fn parse_array_index_json_with_cast() {
 }
 
 #[test]
+fn parse_array_subscript_after_cast() {
+    // Snowflake variant access often casts a path to ARRAY then indexes the
+    // result, e.g. `v:category::array[0]`. The `[N]` is an array subscript,
+    // NOT the postgresql `[]` empty-bracket type suffix.
+    snowflake().one_statement_parses_to(
+        "SELECT v:c::array[0] FROM t",
+        "SELECT CAST(v:c AS ARRAY)[0] FROM t",
+    );
+    snowflake().one_statement_parses_to(
+        "SELECT v:c::array[0]::string FROM t",
+        "SELECT CAST(CAST(v:c AS ARRAY)[0] AS STRING) FROM t",
+    );
+}
+
+#[test]
 fn parse_pivot_of_table_factor_derived() {
     snowflake().verified_stmt(
         "SELECT * FROM (SELECT place_id, weekday, open FROM times AS p) PIVOT(max(open) FOR weekday IN (0, 1, 2, 3, 4, 5, 6)) AS p (place_id, open_sun, open_mon, open_tue, open_wed, open_thu, open_fri, open_sat)"


### PR DESCRIPTION
## Summary

24 parser fixes from running the corpus runner against the rebuilt customer/unparsed corpus, spanning Snowflake, Redshift, BigQuery, MSSQL/T-SQL, MySQL, Databricks, and Postgres. Aggregate: **89.8% → 94.9% pass rate, +8352 passing tests, zero regressions**.

Also bundles infra/docs improvements: corpus-runner dialect fallback chain, CLI flag unification through `dialect_from_str`, and CLAUDE.md learnings captured during the session.

## Parser fixes

**Snowflake**
- Inline `DISTKEY` / `SORTKEY` column attributes (Redshift mirror, no parens)
- Allow `-` in stage path tokens (`@flow_v1/2024-01-01/file.parquet`)
- Allow whitespace inside `[ ... ]` subscripts on variant paths
- Consume balanced `[ <expr> ]` chunks in variant paths
- Accept trailing comma in `FROM` list before `)` / `;` / EOF

**BigQuery**
- Parse procedural `IF cond THEN … [ELSEIF …] [ELSE …] END IF` (new `Statement::If`)
- Require `;` terminator on each IF body statement (per BigQuery docs)
- Treat `TOP` as identifier when not followed by a number
- Allow hyphenated project IDs in `INSERT INTO`

**MSSQL / T-SQL**
- Skip `GO` batch separator between statements
- `DECLARE @var [AS] type [= expr]` syntax
- Accept `MAX` length for `NVARCHAR` / `VARBINARY` / etc.
- `EXEC` with dotted proc name and bare args
- `EXECUTE AS LOGIN = '...'` / `USER = '...'`
- `CREATE TABLE foo AS CLONE OF bar [AT '<ts>']`
- `OPTION (...)` query hint, `LIMIT n WITH TIES`
- Don't take `OPTION` as table alias when followed by `(`

**MySQL**
- Consume `USE | IGNORE | FORCE INDEX [FOR …] (...)` hints

**Databricks**
- Fall through to CURSOR path for `DECLARE … CURSOR FOR …`
- Allow `DECLARE name = expr` (no type, no DEFAULT)

**Postgres / Redshift**
- Accept bare-word `ISNULL` / `NOTNULL` postfix predicates

**Cross-dialect**
- Treat `VIEW` as identifier alias when not part of `LATERAL VIEW`
- Don't eat `[N]` as array-type suffix after cast

## Infra / docs

- Corpus-runner: `dialect_for_name` fallback chain (presto/athena→trino, tsql/fabric→mssql, spark→databricks, materialize→postgres, singlestore/doris/starrocks→mysql, else→generic), recursion limit bumped to 256, removed unreliable statement-count check, bare `customer/` dir reports under `generic`. Landed on `main` so this PR shows real fixes, not infra deltas.
- CLI: all dialect flags resolved through `dialect_from_str` (legacy `--ms` → `mssql` alias kept, unknown flags panic explicitly).
- CLAUDE.md: match-arm ordering trap in `parse_optional_alias`, `is_parse_comma_separated_end` pointer for trailing-comma work, `DECLARE` 5-branch enumeration with discriminator rule, `parse_optional_character_length` vs `parse_optional_precision` split.

## Corpus impact (final)

| Dialect | Passed | Total | Pass Rate | Delta |
|---|---:|---:|---:|---:|
| snowflake | 79797 | 80398 | 99.3% | **+7710** |
| mssql | 2396 | 3018 | 79.4% | **+580** |
| redshift | 23764 | 26926 | 88.3% | **+35** |
| bigquery | 33559 | 35710 | 94.0% | **+32** |
| databricks | 2874 | 3121 | 92.1% | **+20** |
| tsql | 161 | 201 | 80.1% | **+20** |
| mysql | 148 | 187 | 79.1% | **+6** |
| oracle | 1086 | 1583 | 68.6% | **+3** |
| duckdb | 1107 | 1163 | 95.2% | **+2** |
| postgres | 1201 | 1339 | 89.7% | **+2** |
| ansi | 522 | 600 | 87.0% | **+1** |
| clickhouse | 2518 | 2643 | 95.3% | **+1** |

**Total: 150336 / 158357 (94.9%)**, no regressions.