### PR TITLE
fix(redshift): support BACKUP { YES | NO } before CTAS distribution attrs

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7421,7 +7421,12 @@ impl<'a> Parser<'a> {
         let mut dist_key = None;
         let mut sort_key = None;
         loop {
-            if dist_style.is_none() && self.parse_keyword(Keyword::DISTSTYLE) {
+            // Redshift CTAS: BACKUP { YES | NO } may precede the distribution
+            // attributes and the AS keyword. Consume and discard (no lineage
+            // value); the attributes that follow still populate the AST below.
+            if self.parse_keyword(Keyword::BACKUP) {
+                let _ = self.parse_one_of_keywords(&[Keyword::YES, Keyword::NO]);
+            } else if dist_style.is_none() && self.parse_keyword(Keyword::DISTSTYLE) {
                 dist_style = match self.parse_one_of_keywords(&[
                     Keyword::EVEN,
                     Keyword::ALL,

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -432,6 +432,15 @@ fn test_distribution_styles() {
     // Redshift CTAS with numeric column references in DISTKEY/SORTKEY
     let sql = "CREATE TABLE eventdistsort DISTKEY(1) SORTKEY(1, 3) AS SELECT eventid, venueid, dateid, eventname FROM event";
     redshift().one_statement_parses_to(sql, sql);
+
+    // Redshift CTAS: BACKUP { YES | NO } may precede the distribution
+    // attributes and AS. BACKUP carries no lineage and is discarded; the
+    // distribution style is preserved.
+    // https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_AS.html
+    redshift().one_statement_parses_to(
+        "CREATE TABLE foo BACKUP NO DISTSTYLE EVEN AS SELECT b.c1, b.c2 FROM bar AS b",
+        "CREATE TABLE foo DISTSTYLE EVEN AS SELECT b.c1, b.c2 FROM bar AS b",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Redshift `CREATE TABLE ... AS` accepts `BACKUP { YES | NO }` ahead of the `DISTSTYLE`/`DISTKEY`/`SORTKEY` attributes and the `AS` keyword. The parser previously broke on the `BACKUP` keyword in the CTAS path (`Expected end of statement, found: DISTSTYLE`). It is now consumed in the distribution-attribute loop — discarded (no lineage value), while the distribution style that follows still populates the AST.
- Grammar reference: [Redshift CREATE TABLE AS](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_AS.html).
- Added a Redshift unit test in `test_distribution_styles`.

This is the one genuine parser gap of the two remaining Redshift DDL fixtures in QUA-200. The other (`CREATE VIEW` with `DISTSTYLE/DISTKEY/SORTKEY`) is not valid Redshift — dist/sort keys only apply to tables and materialized views, both of which already parse — so no parser change is warranted there (details in the Linear issue).