### PR TITLE
feat(snowflake): support PUT/GET/LIST/REMOVE stage-file commands

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17694,19 +17694,62 @@ impl<'a> Parser<'a> {
     /// The body has no lineage payload, so tokens are consumed to end-of-statement
     /// and joined as a string for roundtrip display.
     pub fn parse_stage_file_operation(&mut self, command: &str) -> Result<Statement, ParserError> {
-        let mut parts: Vec<String> = Vec::new();
+        // These commands (PUT / REMOVE / GET) are single-line statements whose
+        // body is captured opaquely — no lineage payload exists to preserve.
+        //
+        // We must walk the *raw* token stream (whitespace and comments
+        // included) rather than `next_token()`, because in Snowflake `//`
+        // begins a single-line comment. A `file://...` URI therefore tokenizes
+        // as `file`, `:`, then a `SingleLineComment` swallowing the rest of the
+        // line (including any trailing `;`). Skipping whitespace would drop the
+        // URI path entirely and could even pull the following statement into
+        // this one.
+        let mut body = String::new();
         loop {
-            match self.peek_token().token {
+            let tok = self.peek_token_no_skip();
+            match &tok.token {
                 Token::SemiColon | Token::EOF => break,
-                _ => {
-                    let tok = self.next_token();
-                    parts.push(tok.token.to_string());
+                Token::Whitespace(Whitespace::Newline) => {
+                    // PUT / REMOVE / GET are single-line; a newline ends the body.
+                    self.next_token_no_skip();
+                    break;
+                }
+                Token::Whitespace(Whitespace::SingleLineComment { prefix, comment }) => {
+                    // Re-attach the `//`-prefixed text that the tokenizer split
+                    // off (e.g. the bulk of a `file://` URI). The comment runs
+                    // to the end of the line, so the statement ends here.
+                    let trimmed = comment.trim_end();
+                    match trimmed.find(';') {
+                        Some(semi) => {
+                            // The line comment swallowed the statement's `;`
+                            // terminator. Keep the body up to it, then restore a
+                            // real `Token::SemiColon` so any following statement
+                            // still parses (text after `;` was a true comment).
+                            body.push_str(prefix);
+                            body.push_str(trimmed[..semi].trim_end());
+                            let span = tok.span;
+                            self.tokens[self.index] = TokenWithLocation {
+                                token: Token::SemiColon,
+                                span,
+                            };
+                        }
+                        None => {
+                            body.push_str(prefix);
+                            body.push_str(trimmed);
+                            self.next_token_no_skip();
+                        }
+                    }
+                    break;
+                }
+                other => {
+                    body.push_str(&other.to_string());
+                    self.next_token_no_skip();
                 }
             }
         }
         Ok(Statement::StageFileOperation {
             command: command.to_string(),
-            body: parts.join(" "),
+            body: body.trim().to_string(),
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -902,6 +902,9 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::REMOVE => Ok(self.parse_stage_file_operation("REMOVE")?),
                 Keyword::PUT => Ok(self.parse_stage_file_operation("PUT")?),
+                Keyword::GET if dialect_of!(self is SnowflakeDialect | GenericDialect) => {
+                    Ok(self.parse_stage_file_operation("GET")?)
+                }
                 Keyword::SAVEPOINT => Ok(self.parse_savepoint()?),
                 Keyword::RELEASE => Ok(self.parse_release_savepoint()?),
                 Keyword::COMMIT => Ok(self.parse_commit()?),
@@ -1026,6 +1029,22 @@ impl<'a> Parser<'a> {
                         value: vec![expr],
                         additional_assignments: vec![],
                     })
+                }
+                // Snowflake stage-file commands that are not (reserved) keywords:
+                // `LIST`/`LS` enumerate staged files and `RM` is the documented
+                // alias for `REMOVE`. Their bodies are opaque, like PUT/GET.
+                // https://docs.snowflake.com/en/sql-reference/sql/list
+                // https://docs.snowflake.com/en/sql-reference/sql/remove
+                Keyword::NoKeyword
+                    if dialect_of!(self is SnowflakeDialect | GenericDialect)
+                        && w.quote_style.is_none()
+                        && matches!(
+                            w.value.to_ascii_uppercase().as_str(),
+                            "LIST" | "LS" | "RM"
+                        ) =>
+                {
+                    let command = w.value.to_ascii_uppercase();
+                    Ok(self.parse_stage_file_operation(&command)?)
                 }
                 _ => self.expected("an SQL statement", next_token),
             },

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2369,21 +2369,59 @@ fn parse_snowflake_stage_file_operations() {
     match &stmt[0] {
         sqlparser::ast::Statement::StageFileOperation { command, body } => {
             assert_eq!(command, "REMOVE");
-            assert!(body.starts_with("@"));
+            assert_eq!(body, "@~/staging_dir/");
         }
         _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
     }
 
+    // The `//` in a `file://` URI is a Snowflake single-line comment, so the
+    // body must be reconstructed from the raw token stream — otherwise the
+    // path is truncated to `file :`. This is the exact query from QUA-85.
+    let sql = "PUT file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 \
+               @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 \
+               AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE;";
+    let stmt = snowflake().parse_sql_statements(sql).unwrap();
+    assert_eq!(stmt.len(), 1);
+    match &stmt[0] {
+        sqlparser::ast::Statement::StageFileOperation { command, body } => {
+            assert_eq!(command, "PUT");
+            assert_eq!(
+                body,
+                "file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 \
+                 @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 \
+                 AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE"
+            );
+        }
+        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
+    }
+
+    // A simple PUT without a trailing `;` still captures the full file:// URI.
     let stmt = snowflake()
         .parse_sql_statements("PUT file:///tmp/data.csv @mystage")
         .unwrap();
     assert_eq!(stmt.len(), 1);
     match &stmt[0] {
-        sqlparser::ast::Statement::StageFileOperation { command, .. } => {
+        sqlparser::ast::Statement::StageFileOperation { command, body } => {
             assert_eq!(command, "PUT");
+            assert_eq!(body, "file:///tmp/data.csv @mystage");
         }
         _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
     }
+
+    // The `//`-comment must not swallow the `;` terminator and pull a
+    // following statement into the PUT body.
+    let stmt = snowflake()
+        .parse_sql_statements("PUT file:///tmp/data.csv @mystage OVERWRITE=TRUE;\nSELECT 1")
+        .unwrap();
+    assert_eq!(stmt.len(), 2);
+    match &stmt[0] {
+        sqlparser::ast::Statement::StageFileOperation { command, body } => {
+            assert_eq!(command, "PUT");
+            assert_eq!(body, "file:///tmp/data.csv @mystage OVERWRITE=TRUE");
+        }
+        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
+    }
+    assert!(matches!(stmt[1], sqlparser::ast::Statement::Query(_)));
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2358,54 +2358,99 @@ fn parse_snowflake_begin_end_block_no_declare() {
 
 #[test]
 fn parse_snowflake_stage_file_operations() {
-    // Snowflake file-management commands against internal stages.
-    // Parsed but the body is opaque — no lineage payload.
-    // https://docs.snowflake.com/en/sql-reference/sql/remove
-    // https://docs.snowflake.com/en/sql-reference/sql/put
-    let stmt = snowflake()
-        .parse_sql_statements("REMOVE @~/staging_dir/")
-        .unwrap();
-    assert_eq!(stmt.len(), 1);
-    match &stmt[0] {
-        sqlparser::ast::Statement::StageFileOperation { command, body } => {
-            assert_eq!(command, "REMOVE");
-            assert_eq!(body, "@~/staging_dir/");
+    use sqlparser::ast::Statement;
+
+    // Snowflake's file-staging command family (PUT / GET / LIST·LS / REMOVE·RM)
+    // run against internal stages. They neither read nor write table data, so
+    // the body after the command keyword is captured as one opaque string — no
+    // lineage payload exists to preserve.
+    //   https://docs.snowflake.com/en/sql-reference/sql/put
+    //   https://docs.snowflake.com/en/sql-reference/sql/get
+    //   https://docs.snowflake.com/en/sql-reference/sql/list
+    //   https://docs.snowflake.com/en/sql-reference/sql/remove
+    //
+    // The hard part is that Snowflake treats `//` as a single-line comment, so
+    // a `file://` URI tokenizes as `file`, `:`, then a comment swallowing the
+    // rest of the line. The body must be reconstructed from the raw token
+    // stream, otherwise it is truncated to `file :`.
+    let cases = [
+        // (sql, expected command, expected body) — examples adapted from the
+        // Snowflake PUT / GET / LIST / REMOVE documentation.
+        // -- PUT: named stage, user stage (@~), table stage (@%table) --
+        (
+            "PUT file:///tmp/data/mydata.csv @my_int_stage",
+            "PUT",
+            "file:///tmp/data/mydata.csv @my_int_stage",
+        ),
+        (
+            "PUT file:///tmp/data/orders_001.csv @%orders;",
+            "PUT",
+            "file:///tmp/data/orders_001.csv @%orders",
+        ),
+        // Windows-style backslash path + user stage + option.
+        (
+            "PUT file://C:\\temp\\data\\mydata.csv @~ AUTO_COMPRESS=TRUE;",
+            "PUT",
+            "file://C:\\temp\\data\\mydata.csv @~ AUTO_COMPRESS=TRUE",
+        ),
+        // Wildcard in the local path.
+        (
+            "PUT file:///tmp/data/*.csv @%orders;",
+            "PUT",
+            "file:///tmp/data/*.csv @%orders",
+        ),
+        // Full option list.
+        (
+            "PUT file:///tmp/data/mydata.csv @my_int_stage AUTO_COMPRESS=FALSE PARALLEL=4 SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE;",
+            "PUT",
+            "file:///tmp/data/mydata.csv @my_int_stage AUTO_COMPRESS=FALSE PARALLEL=4 SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE",
+        ),
+        // The exact query from QUA-85.
+        (
+            "PUT file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE;",
+            "PUT",
+            "file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE",
+        ),
+        // -- GET: download from a stage to a local directory --
+        (
+            "GET @my_int_stage/mydata.csv.gz file:///tmp/data/;",
+            "GET",
+            "@my_int_stage/mydata.csv.gz file:///tmp/data/",
+        ),
+        (
+            "GET @%orders file:///tmp/data/ PATTERN='.*data.*';",
+            "GET",
+            "@%orders file:///tmp/data/ PATTERN='.*data.*'",
+        ),
+        // -- LIST / LS --
+        ("LIST @my_int_stage;", "LIST", "@my_int_stage"),
+        ("LIST @~/staging_dir/", "LIST", "@~/staging_dir/"),
+        ("LS @~;", "LS", "@~"),
+        // -- REMOVE / RM --
+        ("REMOVE @~/staging_dir/", "REMOVE", "@~/staging_dir/"),
+        ("RM @%orders/myfile;", "RM", "@%orders/myfile"),
+    ];
+
+    for (sql, expected_command, expected_body) in cases {
+        let stmt = snowflake().parse_sql_statements(sql).unwrap();
+        assert_eq!(stmt.len(), 1, "expected one statement for {sql:?}");
+        match &stmt[0] {
+            Statement::StageFileOperation { command, body } => {
+                assert_eq!(command, expected_command, "command mismatch for {sql:?}");
+                assert_eq!(body, expected_body, "body mismatch for {sql:?}");
+            }
+            other => panic!("expected StageFileOperation for {sql:?}, got {other:?}"),
         }
-        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
     }
 
-    // The `//` in a `file://` URI is a Snowflake single-line comment, so the
-    // body must be reconstructed from the raw token stream — otherwise the
-    // path is truncated to `file :`. This is the exact query from QUA-85.
-    let sql = "PUT file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 \
-               @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 \
-               AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE;";
-    let stmt = snowflake().parse_sql_statements(sql).unwrap();
-    assert_eq!(stmt.len(), 1);
+    // Lower-case command keyword normalizes to upper-case in the AST.
+    let stmt = snowflake().parse_sql_statements("ls @~").unwrap();
     match &stmt[0] {
-        sqlparser::ast::Statement::StageFileOperation { command, body } => {
-            assert_eq!(command, "PUT");
-            assert_eq!(
-                body,
-                "file:///tmp/08707734-7670-45a2-a0c9-912fe8a7c727/427d8e97-ea4f-4b51-aeaf-6a9d80f474c4 \
-                 @flow_v1/08707734-7670-45a2-a0c9-912fe8a7c727 \
-                 AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE"
-            );
+        Statement::StageFileOperation { command, body } => {
+            assert_eq!(command, "LS");
+            assert_eq!(body, "@~");
         }
-        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
-    }
-
-    // A simple PUT without a trailing `;` still captures the full file:// URI.
-    let stmt = snowflake()
-        .parse_sql_statements("PUT file:///tmp/data.csv @mystage")
-        .unwrap();
-    assert_eq!(stmt.len(), 1);
-    match &stmt[0] {
-        sqlparser::ast::Statement::StageFileOperation { command, body } => {
-            assert_eq!(command, "PUT");
-            assert_eq!(body, "file:///tmp/data.csv @mystage");
-        }
-        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
+        other => panic!("expected StageFileOperation, got {other:?}"),
     }
 
     // The `//`-comment must not swallow the `;` terminator and pull a
@@ -2415,13 +2460,13 @@ fn parse_snowflake_stage_file_operations() {
         .unwrap();
     assert_eq!(stmt.len(), 2);
     match &stmt[0] {
-        sqlparser::ast::Statement::StageFileOperation { command, body } => {
+        Statement::StageFileOperation { command, body } => {
             assert_eq!(command, "PUT");
             assert_eq!(body, "file:///tmp/data.csv @mystage OVERWRITE=TRUE");
         }
-        _ => panic!("expected StageFileOperation, got {:?}", stmt[0]),
+        other => panic!("expected StageFileOperation, got {other:?}"),
     }
-    assert!(matches!(stmt[1], sqlparser::ast::Statement::Query(_)));
+    assert!(matches!(stmt[1], Statement::Query(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements [QUA-85](https://linear.app/coalesce/issue/QUA-85). Adds full parsing for Snowflake's [file-staging command](https://docs.snowflake.com/en/sql-reference/sql/put) family — **PUT**, **GET**, **LIST** (alias **LS**), **REMOVE** (alias **RM**) — and fixes the `file://` URI body capture that motivated the issue.

These commands are client/server operations against internal stages: they neither read nor write table data, so everything after the command keyword is captured as one opaque `StageFileOperation { command, body }` (no lineage payload to preserve). `PUT`/`REMOVE` already dispatched here; this PR fixes their body handling and extends the family to `GET`/`LIST`/`LS`/`RM`.

### The bug (QUA-85)

Snowflake treats `//` as a single-line comment, so `file:///tmp/...` tokenizes as `file`, `:`, then a `SingleLineComment` swallowing the rest of the line (including the trailing `;`). `parse_stage_file_operation` walked the stream with whitespace/comment-skipping `next_token()`, so:

- the body was truncated to `file :`, and
- in multi-statement input, the following statement could be pulled into the body (skipping ran past the comment and newline into the next statement).

**Fix:** walk the *raw* token stream and re-attach the `//`-prefixed comment text to reconstruct the full opaque body. When the line comment swallowed the statement's `;`, restore a real `Token::SemiColon` so any following statement still parses (text after the `;` was a genuine trailing comment, dropped).

```
Before:  { "command": "PUT", "body": "file :" }
After:   { "command": "PUT", "body": "file:///tmp/.../data @flow_v1/... AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE" }
```

### Command family

- **GET** — keyword; downloads from a stage to a local `file://` path.
- **LIST** / **LS** / **RM** — not (reserved) keywords, matched case-insensitively by word value (per the project convention of not adding narrow keywords to `keywords.rs`).
- All four new arms are gated to `SnowflakeDialect | GenericDialect`, so they don't shadow identifiers in other dialects. `PUT`/`REMOVE` keep their existing (ungated) behavior.

## Tests

`parse_snowflake_stage_file_operations` in `tests/sqlparser_snowflake.rs` is now table-driven over the documented example forms and asserts the exact reconstructed body for each:

- **PUT** — named stage, user stage `@~`, table stage `@%orders`, Windows backslash path, wildcard `*.csv`, full option list (`AUTO_COMPRESS` / `PARALLEL` / `SOURCE_COMPRESSION` / `OVERWRITE`), and the exact QUA-85 query.
- **GET** — `@stage … file://…`, including `PATTERN='…'`.
- **LIST / LS / REMOVE / RM** — stage references, plus lower-case → upper-case command normalization.
- Multi-statement: `PUT …; \n SELECT 1` parses as two statements (the `//` comment doesn't swallow the `SELECT`).

- [x] `cargo test --test sqlparser_snowflake` — 189 passed
- [x] `cargo test --test sqlparser_common` — 251 passed
- [x] Full suite green (the two `sqlparser_error_perf` backtrace-assertion tests fail only locally where `RUST_BACKTRACE` is set; green in CI)
- [x] `cargo fmt`, `cargo clippy` — no new warnings

https://claude.ai/code/session_016fsZziVypMe4NhMg2Cdq69