### PR TITLE
feat: capture SQL security/governance policy applications and definitions

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1413,6 +1413,30 @@ pub struct TablePolicy {
     pub columns: Vec<WithSpan<Ident>>,
 }
 
+/// A tag association `<tag_name> = '<value>'` applied to a table, view, or
+/// column (Snowflake `[ WITH ] TAG ( <tag_name> = '<value>' [ , ... ] )`).
+///
+/// [Snowflake]: https://docs.snowflake.com/en/sql-reference/sql/create-table
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct Tag {
+    #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+    pub name: ObjectName,
+    pub value: String,
+}
+
+impl fmt::Display for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} = '{}'",
+            self.name,
+            escape_single_quote_string(&self.value)
+        )
+    }
+}
+
 /// The kind of a table-level [`TablePolicy`] application. Each kind selects the
 /// keyword used to introduce its column list (`ON`, `ENTITY KEY`, `ALLOWED JOIN
 /// KEYS`).

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1386,6 +1386,73 @@ impl fmt::Display for ColumnPolicy {
     }
 }
 
+/// Table-level security/governance policy applied in a `CREATE TABLE`
+/// (or `CREATE DYNAMIC TABLE`) statement.
+///
+/// Snowflake:
+/// ```sql
+/// [ WITH ] ROW ACCESS POLICY <policy_name> ON ( <col>, ... )
+/// [ WITH ] AGGREGATION POLICY <policy_name> [ ENTITY KEY ( <col>, ... ) ]
+/// [ WITH ] JOIN POLICY <policy_name> [ ALLOWED JOIN KEYS ( <col>, ... ) ]
+/// [ WITH ] STORAGE LIFECYCLE POLICY <policy_name> ON ( <col>, ... )
+/// ```
+/// [Snowflake CREATE TABLE]: https://docs.snowflake.com/en/sql-reference/sql/create-table
+/// [Snowflake CREATE DYNAMIC TABLE]: https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct TablePolicy {
+    pub kind: TablePolicyKind,
+    /// Whether the application carried the optional `WITH` prefix.
+    pub with: bool,
+    #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+    pub policy_name: ObjectName,
+    /// Columns the policy is scoped to. Empty when the column list is omitted
+    /// (e.g. Snowflake `GET_DDL` emits `WITH ROW ACCESS POLICY p` with no `ON`
+    /// when the caller lacks privilege to see the policy).
+    pub columns: Vec<WithSpan<Ident>>,
+}
+
+/// The kind of a table-level [`TablePolicy`] application. Each kind selects the
+/// keyword used to introduce its column list (`ON`, `ENTITY KEY`, `ALLOWED JOIN
+/// KEYS`).
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum TablePolicyKind {
+    /// Snowflake `ROW ACCESS POLICY <name> ON (cols)`.
+    RowAccess,
+    /// Snowflake `AGGREGATION POLICY <name> [ENTITY KEY (cols)]`.
+    Aggregation,
+    /// Snowflake `JOIN POLICY <name> [ALLOWED JOIN KEYS (cols)]`.
+    Join,
+    /// Snowflake dynamic table `STORAGE LIFECYCLE POLICY <name> ON (cols)`.
+    StorageLifecycle,
+}
+
+impl fmt::Display for TablePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.with {
+            write!(f, "WITH ")?;
+        }
+        let (command, columns_keyword) = match self.kind {
+            TablePolicyKind::RowAccess => ("ROW ACCESS POLICY", "ON"),
+            TablePolicyKind::Aggregation => ("AGGREGATION POLICY", "ENTITY KEY"),
+            TablePolicyKind::Join => ("JOIN POLICY", "ALLOWED JOIN KEYS"),
+            TablePolicyKind::StorageLifecycle => ("STORAGE LIFECYCLE POLICY", "ON"),
+        };
+        write!(f, "{command} {}", self.policy_name)?;
+        if !self.columns.is_empty() {
+            write!(
+                f,
+                " {columns_keyword} ({})",
+                display_comma_separated(&self.columns)
+            )?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1419,6 +1419,52 @@ pub struct TablePolicy {
     pub columns: Vec<WithSpan<Ident>>,
 }
 
+/// The kind of a Snowflake policy *definition* (`CREATE ... POLICY`). Each
+/// selects the keyword sequence and the shape of the policy body.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum PolicyKind {
+    /// `CREATE MASKING POLICY`
+    Masking,
+    /// `CREATE ROW ACCESS POLICY`
+    RowAccess,
+    /// `CREATE AGGREGATION POLICY`
+    Aggregation,
+    /// `CREATE PROJECTION POLICY`
+    Projection,
+    /// `CREATE JOIN POLICY`
+    Join,
+}
+
+impl fmt::Display for PolicyKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            PolicyKind::Masking => "MASKING POLICY",
+            PolicyKind::RowAccess => "ROW ACCESS POLICY",
+            PolicyKind::Aggregation => "AGGREGATION POLICY",
+            PolicyKind::Projection => "PROJECTION POLICY",
+            PolicyKind::Join => "JOIN POLICY",
+        })
+    }
+}
+
+/// A single argument in a Snowflake policy signature (`<name> <type>`), e.g. the
+/// `email varchar` in `CREATE MASKING POLICY p AS (email varchar) ...`.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct PolicyArg {
+    pub name: Ident,
+    pub data_type: DataType,
+}
+
+impl fmt::Display for PolicyArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.name, self.data_type)
+    }
+}
+
 /// A Databricks column mask applied in a column definition or `ALTER COLUMN`:
 /// `MASK <function> [ USING COLUMNS ( <col> | <literal> [ , ... ] ) ]`.
 ///

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -881,6 +881,8 @@ pub struct ColumnDef {
     pub mask: Option<ObjectName>,
     pub column_location: Option<ColumnLocation>,
     pub column_policy: Option<ColumnPolicy>,
+    /// Column-level tag associations (Snowflake `[WITH] TAG (k = 'v', ...)`).
+    pub tags: Vec<Tag>,
 }
 
 impl fmt::Display for ColumnDef {
@@ -912,6 +914,10 @@ impl fmt::Display for ColumnDef {
 
         if let Some(column_policy) = &self.column_policy {
             write!(f, "{column_policy}")?;
+        }
+
+        if !self.tags.is_empty() {
+            write!(f, " WITH TAG ({})", display_comma_separated(&self.tags))?;
         }
 
         if let Some(column_location) = &self.column_location {

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -878,7 +878,7 @@ pub struct ColumnDef {
     pub codec: Option<Vec<Expr>>,
     pub options: Vec<ColumnOptionDef>,
     pub column_options: Vec<SqlOption>,
-    pub mask: Option<ObjectName>,
+    pub mask: Option<ColumnMask>,
     pub column_location: Option<ColumnLocation>,
     pub column_policy: Option<ColumnPolicy>,
     /// Column-level tag associations (Snowflake `[WITH] TAG (k = 'v', ...)`).
@@ -909,7 +909,7 @@ impl fmt::Display for ColumnDef {
             )?;
         }
         if let Some(mask) = &self.mask {
-            write!(f, " MASK {mask}")?;
+            write!(f, " {mask}")?;
         }
 
         if let Some(column_policy) = &self.column_policy {
@@ -1419,6 +1419,38 @@ pub struct TablePolicy {
     pub columns: Vec<WithSpan<Ident>>,
 }
 
+/// A Databricks column mask applied in a column definition or `ALTER COLUMN`:
+/// `MASK <function> [ USING COLUMNS ( <col> | <literal> [ , ... ] ) ]`.
+///
+/// The masking logic itself lives in the referenced scalar UDF; the optional
+/// `USING COLUMNS` list supplies extra arguments (other column names and/or
+/// constant literals) to that function.
+///
+/// [Databricks]: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-column-mask
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct ColumnMask {
+    #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+    pub function: ObjectName,
+    /// `USING COLUMNS (...)` arguments: other column names and/or literals.
+    pub using_columns: Vec<Expr>,
+}
+
+impl fmt::Display for ColumnMask {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MASK {}", self.function)?;
+        if !self.using_columns.is_empty() {
+            write!(
+                f,
+                " USING COLUMNS ({})",
+                display_comma_separated(&self.using_columns)
+            )?;
+        }
+        Ok(())
+    }
+}
+
 /// A tag association `<tag_name> = '<value>'` applied to a table, view, or
 /// column (Snowflake `[ WITH ] TAG ( <tag_name> = '<value>' [ , ... ] )`).
 ///
@@ -1458,6 +1490,10 @@ pub enum TablePolicyKind {
     Join,
     /// Snowflake dynamic table `STORAGE LIFECYCLE POLICY <name> ON (cols)`.
     StorageLifecycle,
+    /// Databricks `ROW FILTER <function> ON (cols)`. The `<name>` is a scalar
+    /// UDF returning BOOLEAN; `ON (cols)` supplies its arguments.
+    /// <https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-row-filter>
+    RowFilter,
 }
 
 impl fmt::Display for TablePolicy {
@@ -1470,6 +1506,7 @@ impl fmt::Display for TablePolicy {
             TablePolicyKind::Aggregation => ("AGGREGATION POLICY", "ENTITY KEY"),
             TablePolicyKind::Join => ("JOIN POLICY", "ALLOWED JOIN KEYS"),
             TablePolicyKind::StorageLifecycle => ("STORAGE LIFECYCLE POLICY", "ON"),
+            TablePolicyKind::RowFilter => ("ROW FILTER", "ON"),
         };
         write!(f, "{command} {}", self.policy_name)?;
         if !self.columns.is_empty() {

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::ast::{
     ColumnDef, DistributionStyle, EngineSpec, Expr, FileFormat, HiveDistributionStyle, HiveFormat,
     Ident, ObjectName, OnCommit, PartitionBoundSpec, Query, SqlOption, Statement, TableConstraint,
-    TablePolicy,
+    TablePolicy, Tag,
 };
 use crate::parser::ParserError;
 use sqlparser::ast::TableProjection;
@@ -98,6 +98,7 @@ pub struct CreateTableBuilder {
     pub partition_of: Option<ObjectName>,
     pub partition_bound: Option<PartitionBoundSpec>,
     pub table_policies: Vec<TablePolicy>,
+    pub table_tags: Vec<Tag>,
 }
 
 impl CreateTableBuilder {
@@ -153,6 +154,7 @@ impl CreateTableBuilder {
             partition_of: None,
             partition_bound: None,
             table_policies: vec![],
+            table_tags: vec![],
         }
     }
     pub fn or_replace(mut self, or_replace: bool) -> Self {
@@ -398,6 +400,11 @@ impl CreateTableBuilder {
         self
     }
 
+    pub fn table_tags(mut self, table_tags: Vec<Tag>) -> Self {
+        self.table_tags = table_tags;
+        self
+    }
+
     pub fn build(self) -> Statement {
         Statement::CreateTable {
             or_replace: self.or_replace,
@@ -450,6 +457,7 @@ impl CreateTableBuilder {
             partition_of: self.partition_of,
             partition_bound: self.partition_bound,
             table_policies: self.table_policies,
+            table_tags: self.table_tags,
         }
     }
 }
@@ -512,6 +520,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 partition_of,
                 partition_bound,
                 table_policies,
+                table_tags,
             } => Ok(Self {
                 or_replace,
                 temporary,
@@ -563,6 +572,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 partition_of,
                 partition_bound,
                 table_policies,
+                table_tags,
             }),
             _ => Err(ParserError::ParserError(
                 format!("Expected create table statement, but received: {stmt}").into(),

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::ast::{
     ColumnDef, DistributionStyle, EngineSpec, Expr, FileFormat, HiveDistributionStyle, HiveFormat,
     Ident, ObjectName, OnCommit, PartitionBoundSpec, Query, SqlOption, Statement, TableConstraint,
+    TablePolicy,
 };
 use crate::parser::ParserError;
 use sqlparser::ast::TableProjection;
@@ -96,6 +97,7 @@ pub struct CreateTableBuilder {
     pub inherits: Option<Vec<ObjectName>>,
     pub partition_of: Option<ObjectName>,
     pub partition_bound: Option<PartitionBoundSpec>,
+    pub table_policies: Vec<TablePolicy>,
 }
 
 impl CreateTableBuilder {
@@ -150,6 +152,7 @@ impl CreateTableBuilder {
             inherits: None,
             partition_of: None,
             partition_bound: None,
+            table_policies: vec![],
         }
     }
     pub fn or_replace(mut self, or_replace: bool) -> Self {
@@ -390,6 +393,11 @@ impl CreateTableBuilder {
         self
     }
 
+    pub fn table_policies(mut self, table_policies: Vec<TablePolicy>) -> Self {
+        self.table_policies = table_policies;
+        self
+    }
+
     pub fn build(self) -> Statement {
         Statement::CreateTable {
             or_replace: self.or_replace,
@@ -441,6 +449,7 @@ impl CreateTableBuilder {
             inherits: self.inherits,
             partition_of: self.partition_of,
             partition_bound: self.partition_bound,
+            table_policies: self.table_policies,
         }
     }
 }
@@ -502,6 +511,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 inherits,
                 partition_of,
                 partition_bound,
+                table_policies,
             } => Ok(Self {
                 or_replace,
                 temporary,
@@ -552,6 +562,7 @@ impl TryFrom<Statement> for CreateTableBuilder {
                 inherits,
                 partition_of,
                 partition_bound,
+                table_policies,
             }),
             _ => Err(ParserError::ParserError(
                 format!("Expected create table statement, but received: {stmt}").into(),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -39,8 +39,9 @@ pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnLocation,
     ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty, ConstraintCharacteristics,
     CreateTableLikeOption, Deduplicate, GeneratedAs, IndexType, KeyOrIndexDisplay, Partition,
-    ProcedureParam, ReferentialAction, TableConstraint, TableProjection,
-    UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation, ViewSecurity,
+    ProcedureParam, ReferentialAction, TableConstraint, TablePolicy, TablePolicyKind,
+    TableProjection, UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
+    ViewSecurity,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
@@ -1986,6 +1987,10 @@ pub enum Statement {
         partition_of: Option<ObjectName>,
         /// PostgreSQL partition bound specification (`FOR VALUES ...` or `DEFAULT`).
         partition_bound: Option<PartitionBoundSpec>,
+        /// Table-level security/governance policy applications (Snowflake
+        /// `ROW ACCESS` / `AGGREGATION` / `JOIN` / `STORAGE LIFECYCLE POLICY`).
+        /// Preserved so column-level lineage can surface which policies guard a table.
+        table_policies: Vec<TablePolicy>,
     },
     /// ```sql
     /// CREATE VIRTUAL TABLE .. USING <module_name> (<module_args>)`
@@ -3499,6 +3504,7 @@ impl fmt::Display for Statement {
                 dynamic,
                 iceberg,
                 hybrid,
+                table_policies,
             } => {
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:
@@ -3736,6 +3742,9 @@ impl fmt::Display for Statement {
                 }
                 if *copy_grants {
                     write!(f, " COPY GRANTS")?;
+                }
+                for policy in table_policies {
+                    write!(f, " {policy}")?;
                 }
                 if let Some(query) = query {
                     write!(f, " AS {query}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -40,7 +40,7 @@ pub use self::ddl::{
     ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty, ConstraintCharacteristics,
     CreateTableLikeOption, Deduplicate, GeneratedAs, IndexType, KeyOrIndexDisplay, Partition,
     ProcedureParam, ReferentialAction, TableConstraint, TablePolicy, TablePolicyKind,
-    TableProjection, UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
+    TableProjection, Tag, UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
     ViewSecurity,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
@@ -1991,6 +1991,8 @@ pub enum Statement {
         /// `ROW ACCESS` / `AGGREGATION` / `JOIN` / `STORAGE LIFECYCLE POLICY`).
         /// Preserved so column-level lineage can surface which policies guard a table.
         table_policies: Vec<TablePolicy>,
+        /// Table-level tag associations (Snowflake `[WITH] TAG (k = 'v', ...)`).
+        table_tags: Vec<Tag>,
     },
     /// ```sql
     /// CREATE VIRTUAL TABLE .. USING <module_name> (<module_args>)`
@@ -3505,6 +3507,7 @@ impl fmt::Display for Statement {
                 iceberg,
                 hybrid,
                 table_policies,
+                table_tags,
             } => {
                 // We want to allow the following options
                 // Empty column list, allowed by PostgreSQL:
@@ -3745,6 +3748,9 @@ impl fmt::Display for Statement {
                 }
                 for policy in table_policies {
                     write!(f, " {policy}")?;
+                }
+                if !table_tags.is_empty() {
+                    write!(f, " WITH TAG ({})", display_comma_separated(table_tags))?;
                 }
                 if let Some(query) = query {
                     write!(f, " AS {query}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2067,6 +2067,26 @@ pub enum Statement {
         /// Trailing `key = value` options (COMMENT, PROPAGATE, ON_CONFLICT).
         options: Vec<SqlOption>,
     },
+    /// ```sql
+    /// CREATE [OR REPLACE] ROW ACCESS POLICY [IF NOT EXISTS] <name> ON <table>
+    ///   [ GRANT TO ( <grantee> [, ...] ) ]
+    ///   FILTER USING ( <predicate> )
+    /// ```
+    /// BigQuery row-level security policy. The target `table_name` and the
+    /// `filter_using` predicate (which may itself contain a subquery) are
+    /// preserved for lineage.
+    /// [BigQuery]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language
+    CreateRowAccessPolicy {
+        or_replace: bool,
+        if_not_exists: bool,
+        name: ObjectName,
+        #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+        table_name: ObjectName,
+        /// `GRANT TO (...)` IAM principals (string literals); empty when omitted.
+        grant_to: Vec<Expr>,
+        /// `FILTER USING (<predicate>)`.
+        filter_using: Box<Expr>,
+    },
     /// See [postgres](https://www.postgresql.org/docs/current/sql-createrole.html)
     CreateRole {
         names: Vec<ObjectName>,
@@ -3939,6 +3959,26 @@ impl fmt::Display for Statement {
                 for option in options {
                     write!(f, " {option}")?;
                 }
+                Ok(())
+            }
+            Statement::CreateRowAccessPolicy {
+                or_replace,
+                if_not_exists,
+                name,
+                table_name,
+                grant_to,
+                filter_using,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}ROW ACCESS POLICY {if_not_exists}{name} ON {table_name}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
+                )?;
+                if !grant_to.is_empty() {
+                    write!(f, " GRANT TO ({})", display_comma_separated(grant_to))?;
+                }
+                write!(f, " FILTER USING ({filter_using})")?;
                 Ok(())
             }
             Statement::CreateRole {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -39,9 +39,9 @@ pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnLocation,
     ColumnMask, ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty,
     ConstraintCharacteristics, CreateTableLikeOption, Deduplicate, GeneratedAs, IndexType,
-    KeyOrIndexDisplay, Partition, ProcedureParam, ReferentialAction, TableConstraint, TablePolicy,
-    TablePolicyKind, TableProjection, Tag, UserDefinedTypeCompositeAttributeDef,
-    UserDefinedTypeRepresentation, ViewSecurity,
+    KeyOrIndexDisplay, Partition, PolicyArg, PolicyKind, ProcedureParam, ReferentialAction,
+    TableConstraint, TablePolicy, TablePolicyKind, TableProjection, Tag,
+    UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation, ViewSecurity,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
@@ -2025,6 +2025,31 @@ pub enum Statement {
     /// ```sql
     /// CREATE ROLE
     /// ```
+    /// ```sql
+    /// CREATE [OR REPLACE] { MASKING | ROW ACCESS | AGGREGATION | PROJECTION | JOIN } POLICY
+    ///   [IF NOT EXISTS] <name> AS ( [<arg> <type> [, ...]] ) RETURNS <type> -> <body>
+    ///   [COMMENT = '...'] [EXEMPT_OTHER_POLICIES = { TRUE | FALSE }]
+    /// ```
+    /// Snowflake security/governance policy *definition*. The masking/row-access
+    /// condition lives in `body` (a real `Expr`, so any subqueries/table refs are
+    /// visible to lineage).
+    ///
+    /// [Snowflake]: https://docs.snowflake.com/en/sql-reference/sql/create-masking-policy
+    CreatePolicy {
+        or_replace: bool,
+        if_not_exists: bool,
+        kind: PolicyKind,
+        #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+        name: ObjectName,
+        /// Signature args `(name type, ...)`; empty for `AS ()`.
+        args: Vec<PolicyArg>,
+        /// `RETURNS <type>`.
+        returns: DataType,
+        /// `-> <body>` condition/return expression.
+        body: Box<Expr>,
+        /// Trailing `COMMENT = '...'`, `EXEMPT_OTHER_POLICIES = { TRUE | FALSE }`.
+        options: Vec<SqlOption>,
+    },
     /// See [postgres](https://www.postgresql.org/docs/current/sql-createrole.html)
     CreateRole {
         names: Vec<ObjectName>,
@@ -3847,6 +3872,28 @@ impl fmt::Display for Statement {
                 }
                 if let Some(predicate) = predicate {
                     write!(f, " WHERE {predicate}")?;
+                }
+                Ok(())
+            }
+            Statement::CreatePolicy {
+                or_replace,
+                if_not_exists,
+                kind,
+                name,
+                args,
+                returns,
+                body,
+                options,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}{kind} {if_not_exists}{name} AS ({args}) RETURNS {returns} -> {body}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
+                    args = display_comma_separated(args),
+                )?;
+                for option in options {
+                    write!(f, " {option}")?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -37,11 +37,11 @@ pub use self::dcl::{
 };
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterTableOperation, ColumnDef, ColumnLocation,
-    ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty, ConstraintCharacteristics,
-    CreateTableLikeOption, Deduplicate, GeneratedAs, IndexType, KeyOrIndexDisplay, Partition,
-    ProcedureParam, ReferentialAction, TableConstraint, TablePolicy, TablePolicyKind,
-    TableProjection, Tag, UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
-    ViewSecurity,
+    ColumnMask, ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty,
+    ConstraintCharacteristics, CreateTableLikeOption, Deduplicate, GeneratedAs, IndexType,
+    KeyOrIndexDisplay, Partition, ProcedureParam, ReferentialAction, TableConstraint, TablePolicy,
+    TablePolicyKind, TableProjection, Tag, UserDefinedTypeCompositeAttributeDef,
+    UserDefinedTypeRepresentation, ViewSecurity,
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2050,6 +2050,23 @@ pub enum Statement {
         /// Trailing `COMMENT = '...'`, `EXEMPT_OTHER_POLICIES = { TRUE | FALSE }`.
         options: Vec<SqlOption>,
     },
+    /// ```sql
+    /// CREATE [OR REPLACE] TAG [IF NOT EXISTS] <name>
+    ///   [ ALLOWED_VALUES '<v1>' [, '<v2>' ...] ]
+    ///   [ <key> = <value> ... ]   -- e.g. COMMENT, PROPAGATE, ON_CONFLICT
+    /// ```
+    /// Snowflake tag *definition*.
+    /// [Snowflake]: https://docs.snowflake.com/en/sql-reference/sql/create-tag
+    CreateTag {
+        or_replace: bool,
+        if_not_exists: bool,
+        #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
+        name: ObjectName,
+        /// `ALLOWED_VALUES '<v>' [, ...]` (empty when omitted).
+        allowed_values: Vec<String>,
+        /// Trailing `key = value` options (COMMENT, PROPAGATE, ON_CONFLICT).
+        options: Vec<SqlOption>,
+    },
     /// See [postgres](https://www.postgresql.org/docs/current/sql-createrole.html)
     CreateRole {
         names: Vec<ObjectName>,
@@ -3892,6 +3909,33 @@ impl fmt::Display for Statement {
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     args = display_comma_separated(args),
                 )?;
+                for option in options {
+                    write!(f, " {option}")?;
+                }
+                Ok(())
+            }
+            Statement::CreateTag {
+                or_replace,
+                if_not_exists,
+                name,
+                allowed_values,
+                options,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}TAG {if_not_exists}{name}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
+                )?;
+                if !allowed_values.is_empty() {
+                    write!(f, " ALLOWED_VALUES ")?;
+                    for (i, v) in allowed_values.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "'{}'", value::escape_single_quote_string(v))?;
+                    }
+                }
                 for option in options {
                     write!(f, " {option}")?;
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8325,13 +8325,16 @@ impl<'a> Parser<'a> {
             None
         };
 
-        // Skip optional [WITH] TAG (...) clause on columns (Snowflake)
+        // Optional [WITH] TAG (...) clause on columns (Snowflake), captured.
+        let mut tags = vec![];
         if self.parse_keyword(Keyword::WITH) {
-            if !self.parse_optional_tag_clause() {
+            if let Some(parsed) = self.maybe_parse_tags()? {
+                tags = parsed;
+            } else {
                 self.prev_token();
             }
-        } else {
-            self.parse_optional_tag_clause();
+        } else if let Some(parsed) = self.maybe_parse_tags()? {
+            tags = parsed;
         }
 
         // COMMENT may appear after MASKING POLICY / TAG (Snowflake)
@@ -8372,6 +8375,7 @@ impl<'a> Parser<'a> {
             mask,
             column_location,
             column_policy,
+            tags,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7552,59 +7552,34 @@ impl<'a> Parser<'a> {
         let mut on_commit: Option<OnCommit> = None;
         let mut strict = false;
         let mut inherits: Option<Vec<ObjectName>> = None;
+        let mut table_policies: Vec<TablePolicy> = vec![];
 
         loop {
-            // [WITH] ROW ACCESS POLICY <policy_name> ON (<col>, ...) (Snowflake)
-            // and [WITH] TAG (...). Handled before WITH (...) options so the
-            // WITH prefix doesn't force parse_options to consume LParen.
+            // Table-level security/governance policy applications (Snowflake),
+            // each with an optional `WITH` prefix. Handled before the WITH (...)
+            // options so the prefix doesn't force parse_options to consume LParen.
+            //   [WITH] ROW ACCESS POLICY <name> ON (cols)
+            //   [WITH] AGGREGATION POLICY <name> [ENTITY KEY (cols)]
+            //   [WITH] JOIN POLICY <name> [ALLOWED JOIN KEYS (cols)]
+            //   [WITH] STORAGE LIFECYCLE POLICY <name> ON (cols)  (dynamic tables)
+            //   [WITH] TAG (...)
             // https://docs.snowflake.com/en/sql-reference/sql/create-table
-            if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
-                let _policy = self.parse_object_name(false)?;
-                // ON (cols) is optional — Snowflake's GET_DDL omits it when the caller
-                // lacks privilege to see the policy ("WITH ROW ACCESS POLICY unknown_policy").
-                if self.parse_keyword(Keyword::ON) {
-                    self.expect_token(&Token::LParen)?;
-                    let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-                    self.expect_token(&Token::RParen)?;
-                }
+            // https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table
+            if let Some(policy) = self.maybe_parse_table_policy(false)? {
+                table_policies.push(policy);
                 continue;
             }
             {
                 let with = self.parse_keyword(Keyword::WITH);
-                if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
-                    let _policy = self.parse_object_name(false)?;
-                    if self.parse_keyword(Keyword::ON) {
-                        self.expect_token(&Token::LParen)?;
-                        let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-                        self.expect_token(&Token::RParen)?;
+                if with {
+                    if let Some(policy) = self.maybe_parse_table_policy(true)? {
+                        table_policies.push(policy);
+                        continue;
+                    } else if self.parse_optional_tag_clause() {
+                        continue;
+                    } else {
+                        self.prev_token();
                     }
-                    continue;
-                } else if with
-                    && matches!(self.peek_token_kind(), Token::Word(w) if w.value.eq_ignore_ascii_case("STORAGE"))
-                {
-                    // Snowflake Dynamic Table: `WITH STORAGE LIFECYCLE POLICY
-                    // <name> ON (cols)`. Mirrors ROW ACCESS POLICY above —
-                    // consume the clause; the ON columns are the table's own
-                    // outputs, so no extra lineage edge. STORAGE / LIFECYCLE /
-                    // POLICY aren't reserved keywords, so skip by value up to ON.
-                    // https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table
-                    self.next_token(); // STORAGE
-                    while !matches!(self.peek_token_kind(), Token::EOF)
-                        && !matches!(self.peek_token_kind(), Token::Word(w) if w.keyword == Keyword::ON)
-                        && !matches!(self.peek_token_kind(), Token::Word(w) if w.keyword == Keyword::AS)
-                    {
-                        self.next_token();
-                    }
-                    if self.parse_keyword(Keyword::ON) {
-                        self.expect_token(&Token::LParen)?;
-                        let _cols = self.parse_comma_separated(|p| p.parse_identifier(false))?;
-                        self.expect_token(&Token::RParen)?;
-                    }
-                    continue;
-                } else if with && self.parse_optional_tag_clause() {
-                    continue;
-                } else if with {
-                    self.prev_token();
                 }
             }
 
@@ -8120,6 +8095,7 @@ impl<'a> Parser<'a> {
             .copy_grants(copy_grants)
             .location(location)
             .inherits(inherits)
+            .table_policies(table_policies)
             .build())
     }
 
@@ -9110,6 +9086,73 @@ impl<'a> Parser<'a> {
     /// Skip an optional `TAG (qualified_name = 'value', ...)` clause (Snowflake).
     /// Consumes the TAG keyword and the parenthesized list if present.
     /// Returns true if a TAG clause was consumed.
+    /// Try to parse a table-level Snowflake security/governance policy
+    /// application (`ROW ACCESS` / `AGGREGATION` / `JOIN` / `STORAGE LIFECYCLE
+    /// POLICY`). `with` records whether the optional `WITH` keyword was already
+    /// consumed by the caller, so the application round-trips. Returns `None`
+    /// (without consuming tokens beyond a probe) when the next tokens don't
+    /// introduce a table policy.
+    /// <https://docs.snowflake.com/en/sql-reference/sql/create-table>
+    fn maybe_parse_table_policy(&mut self, with: bool) -> Result<Option<TablePolicy>, ParserError> {
+        let kind = if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
+            TablePolicyKind::RowAccess
+        } else if self.parse_keywords(&[Keyword::AGGREGATION, Keyword::POLICY]) {
+            TablePolicyKind::Aggregation
+        } else if self.parse_keywords(&[Keyword::JOIN, Keyword::POLICY]) {
+            TablePolicyKind::Join
+        } else if self.peek_word_ci("STORAGE") {
+            // STORAGE / LIFECYCLE aren't reserved keywords, so match by value.
+            let idx = self.index;
+            self.next_token(); // STORAGE
+            if self.parse_word_ci("LIFECYCLE") && self.parse_keyword(Keyword::POLICY) {
+                TablePolicyKind::StorageLifecycle
+            } else {
+                self.index = idx;
+                return Ok(None);
+            }
+        } else {
+            return Ok(None);
+        };
+
+        let policy_name = self.parse_object_name(false)?;
+
+        // The keyword introducing the (optional) scoped-column list depends on
+        // the policy kind: ON / ENTITY KEY / ALLOWED JOIN KEYS.
+        let columns = match kind {
+            TablePolicyKind::RowAccess | TablePolicyKind::StorageLifecycle => {
+                if self.parse_keyword(Keyword::ON) {
+                    self.parse_parenthesized_column_list(Mandatory, false)?
+                } else {
+                    vec![]
+                }
+            }
+            TablePolicyKind::Aggregation => {
+                if self.parse_word_ci("ENTITY") {
+                    self.expect_keyword(Keyword::KEY)?;
+                    self.parse_parenthesized_column_list(Mandatory, false)?
+                } else {
+                    vec![]
+                }
+            }
+            TablePolicyKind::Join => {
+                if self.parse_word_ci("ALLOWED") {
+                    self.expect_keyword(Keyword::JOIN)?;
+                    self.expect_keyword(Keyword::KEYS)?;
+                    self.parse_parenthesized_column_list(Mandatory, false)?
+                } else {
+                    vec![]
+                }
+            }
+        };
+
+        Ok(Some(TablePolicy {
+            kind,
+            with,
+            policy_name,
+            columns,
+        }))
+    }
+
     fn parse_optional_tag_clause(&mut self) -> bool {
         if self.parse_keyword(Keyword::TAG) {
             if self.consume_token(&Token::LParen) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8303,8 +8303,22 @@ impl<'a> Parser<'a> {
 
         let column_options = self.parse_options(Keyword::OPTIONS)?;
 
+        // Databricks column mask: `MASK <func> [USING COLUMNS (<col>|<literal>, ...)]`.
+        // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-column-mask
         let mask = if self.parse_keyword(Keyword::MASK) {
-            Some(self.parse_object_name(false)?)
+            let function = self.parse_object_name(false)?;
+            let using_columns = if self.parse_keywords(&[Keyword::USING, Keyword::COLUMNS]) {
+                self.expect_token(&Token::LParen)?;
+                let cols = self.parse_comma_separated(|p| p.parse_expr())?;
+                self.expect_token(&Token::RParen)?;
+                cols
+            } else {
+                vec![]
+            };
+            Some(ColumnMask {
+                function,
+                using_columns,
+            })
         } else {
             None
         };
@@ -9089,8 +9103,16 @@ impl<'a> Parser<'a> {
     /// introduce a table policy.
     /// <https://docs.snowflake.com/en/sql-reference/sql/create-table>
     fn maybe_parse_table_policy(&mut self, with: bool) -> Result<Option<TablePolicy>, ParserError> {
-        let kind = if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
-            TablePolicyKind::RowAccess
+        let kind = if self.parse_keyword(Keyword::ROW) {
+            // Snowflake `ROW ACCESS POLICY` vs Databricks `ROW FILTER`.
+            if self.parse_keywords(&[Keyword::ACCESS, Keyword::POLICY]) {
+                TablePolicyKind::RowAccess
+            } else if self.parse_keyword(Keyword::FILTER) {
+                TablePolicyKind::RowFilter
+            } else {
+                self.prev_token(); // put back ROW
+                return Ok(None);
+            }
         } else if self.parse_keywords(&[Keyword::AGGREGATION, Keyword::POLICY]) {
             TablePolicyKind::Aggregation
         } else if self.parse_keywords(&[Keyword::JOIN, Keyword::POLICY]) {
@@ -9114,7 +9136,9 @@ impl<'a> Parser<'a> {
         // The keyword introducing the (optional) scoped-column list depends on
         // the policy kind: ON / ENTITY KEY / ALLOWED JOIN KEYS.
         let columns = match kind {
-            TablePolicyKind::RowAccess | TablePolicyKind::StorageLifecycle => {
+            TablePolicyKind::RowAccess
+            | TablePolicyKind::StorageLifecycle
+            | TablePolicyKind::RowFilter => {
                 if self.parse_keyword(Keyword::ON) {
                     self.parse_parenthesized_column_list(Mandatory, false)?
                 } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4891,6 +4891,8 @@ impl<'a> Parser<'a> {
             self.next_token(); // SEMANTIC
             self.next_token(); // VIEW
             self.parse_create_semantic_view(or_replace)
+        } else if self.parse_keyword(Keyword::TAG) {
+            self.parse_create_tag(or_replace)
         } else if let Some(stmt) = self.maybe_parse(|p| p.parse_create_snowflake_policy(or_replace))
         {
             // Snowflake security/governance policy definitions
@@ -5010,6 +5012,39 @@ impl<'a> Parser<'a> {
             args,
             returns,
             body,
+            options,
+        })
+    }
+
+    /// Parse a Snowflake `CREATE TAG` definition. `TAG` has already been consumed.
+    /// `CREATE [OR REPLACE] TAG [IF NOT EXISTS] <name> [ALLOWED_VALUES '<v>' [, ...]]
+    /// [<key> = <value> ...]`.
+    /// <https://docs.snowflake.com/en/sql-reference/sql/create-tag>
+    fn parse_create_tag(&mut self, or_replace: bool) -> Result<Statement, ParserError> {
+        let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let name = self.parse_object_name(false)?;
+
+        // `ALLOWED_VALUES` is a bare comma-separated list of string literals
+        // (no parens, no `=`); it isn't a reserved keyword, so match by value.
+        let allowed_values = if self.parse_word_ci("ALLOWED_VALUES") {
+            self.parse_comma_separated(|p| p.parse_literal_string())?
+        } else {
+            vec![]
+        };
+
+        // Trailing `key = value` options (COMMENT, PROPAGATE, ON_CONFLICT).
+        let mut options = vec![];
+        while matches!(self.peek_token_kind(), Token::Word(_))
+            && self.peek_nth_token(1).token == Token::Eq
+        {
+            options.push(self.parse_sql_option()?);
+        }
+
+        Ok(Statement::CreateTag {
+            or_replace,
+            if_not_exists,
+            name,
+            allowed_values,
             options,
         })
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4891,6 +4891,14 @@ impl<'a> Parser<'a> {
             self.next_token(); // SEMANTIC
             self.next_token(); // VIEW
             self.parse_create_semantic_view(or_replace)
+        } else if let Some(stmt) = self.maybe_parse(|p| p.parse_create_snowflake_policy(or_replace))
+        {
+            // Snowflake security/governance policy definitions
+            // (CREATE { MASKING | ROW ACCESS | AGGREGATION | PROJECTION | JOIN }
+            // POLICY ... AS (sig) RETURNS type -> body). maybe_parse reverts and
+            // falls through for non-Snowflake shapes (e.g. BigQuery's
+            // `ROW ACCESS POLICY ... ON table`), which the generic fallback handles.
+            Ok(stmt)
         } else {
             // Generic fallback: skip tokens until end of statement
             // This handles dialect-specific CREATE statements like:
@@ -4932,6 +4940,78 @@ impl<'a> Parser<'a> {
                 _ => self.expected("an object type after CREATE", token),
             }
         }
+    }
+
+    /// Parse a Snowflake security/governance policy *definition*:
+    /// `{ MASKING | ROW ACCESS | AGGREGATION | PROJECTION | JOIN } POLICY
+    /// [IF NOT EXISTS] <name> AS ( [<arg> <type>, ...] ) RETURNS <type> -> <body>
+    /// [COMMENT = '...'] [EXEMPT_OTHER_POLICIES = { TRUE | FALSE }]`.
+    ///
+    /// Errors (so the caller's `maybe_parse` reverts) when the next tokens don't
+    /// form this shape — in particular the `AS` check rejects BigQuery's
+    /// `ROW ACCESS POLICY ... ON <table>` form, leaving it to other handlers.
+    /// <https://docs.snowflake.com/en/sql-reference/sql/create-masking-policy>
+    fn parse_create_snowflake_policy(
+        &mut self,
+        or_replace: bool,
+    ) -> Result<Statement, ParserError> {
+        let kind = if self.parse_keywords(&[Keyword::MASKING, Keyword::POLICY]) {
+            PolicyKind::Masking
+        } else if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
+            PolicyKind::RowAccess
+        } else if self.parse_keywords(&[Keyword::AGGREGATION, Keyword::POLICY]) {
+            PolicyKind::Aggregation
+        } else if self.parse_keywords(&[Keyword::PROJECTION, Keyword::POLICY]) {
+            PolicyKind::Projection
+        } else if self.parse_keywords(&[Keyword::JOIN, Keyword::POLICY]) {
+            PolicyKind::Join
+        } else {
+            return self.expected("a policy kind", self.peek_token());
+        };
+
+        let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let name = self.parse_object_name(false)?;
+
+        // The Snowflake form is `AS (sig) RETURNS type -> body`. If `AS` is not
+        // next, this is a different policy shape (BigQuery/Postgres/Redshift) —
+        // error so the caller falls back.
+        self.expect_keyword(Keyword::AS)?;
+        self.expect_token(&Token::LParen)?;
+        let args = if self.consume_token(&Token::RParen) {
+            vec![]
+        } else {
+            let args = self.parse_comma_separated(|p| {
+                let name = p.parse_identifier_no_span()?;
+                let data_type = p.parse_data_type()?;
+                Ok(PolicyArg { name, data_type })
+            })?;
+            self.expect_token(&Token::RParen)?;
+            args
+        };
+
+        self.expect_keyword(Keyword::RETURNS)?;
+        let returns = self.parse_data_type()?;
+        self.expect_token(&Token::Arrow)?;
+        let body = Box::new(self.parse_expr()?);
+
+        // Trailing `key = value` options (COMMENT, EXEMPT_OTHER_POLICIES).
+        let mut options = vec![];
+        while matches!(self.peek_token_kind(), Token::Word(_))
+            && self.peek_nth_token(1).token == Token::Eq
+        {
+            options.push(self.parse_sql_option()?);
+        }
+
+        Ok(Statement::CreatePolicy {
+            or_replace,
+            if_not_exists,
+            kind,
+            name,
+            args,
+            returns,
+            body,
+            options,
+        })
     }
 
     /// Parse a CACHE TABLE statement

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4899,8 +4899,12 @@ impl<'a> Parser<'a> {
             // (CREATE { MASKING | ROW ACCESS | AGGREGATION | PROJECTION | JOIN }
             // POLICY ... AS (sig) RETURNS type -> body). maybe_parse reverts and
             // falls through for non-Snowflake shapes (e.g. BigQuery's
-            // `ROW ACCESS POLICY ... ON table`), which the generic fallback handles.
+            // `ROW ACCESS POLICY ... ON table`), handled next.
             Ok(stmt)
+        } else if self.parse_keywords(&[Keyword::ROW, Keyword::ACCESS, Keyword::POLICY]) {
+            // BigQuery row-level security:
+            // ROW ACCESS POLICY <name> ON <table> [GRANT TO (...)] FILTER USING (expr)
+            self.parse_create_row_access_policy(or_replace)
         } else {
             // Generic fallback: skip tokens until end of statement
             // This handles dialect-specific CREATE statements like:
@@ -5013,6 +5017,44 @@ impl<'a> Parser<'a> {
             returns,
             body,
             options,
+        })
+    }
+
+    /// Parse a BigQuery `CREATE ROW ACCESS POLICY`. The `ROW ACCESS POLICY`
+    /// keywords have already been consumed.
+    /// `<name> ON <table> [GRANT TO (<grantee>, ...)] FILTER USING (<predicate>)`.
+    /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language>
+    fn parse_create_row_access_policy(
+        &mut self,
+        or_replace: bool,
+    ) -> Result<Statement, ParserError> {
+        let if_not_exists = self.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let name = self.parse_object_name(false)?;
+        self.expect_keyword(Keyword::ON)?;
+        let table_name = self.parse_object_name(false)?;
+
+        let grant_to = if self.parse_keywords(&[Keyword::GRANT, Keyword::TO]) {
+            self.expect_token(&Token::LParen)?;
+            let grantees = self.parse_comma_separated(|p| p.parse_expr())?;
+            self.expect_token(&Token::RParen)?;
+            grantees
+        } else {
+            vec![]
+        };
+
+        self.expect_keyword(Keyword::FILTER)?;
+        self.expect_keyword(Keyword::USING)?;
+        self.expect_token(&Token::LParen)?;
+        let filter_using = Box::new(self.parse_expr()?);
+        self.expect_token(&Token::RParen)?;
+
+        Ok(Statement::CreateRowAccessPolicy {
+            or_replace,
+            if_not_exists,
+            name,
+            table_name,
+            grant_to,
+            filter_using,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7517,19 +7517,6 @@ impl<'a> Parser<'a> {
         let hive_formats = self.parse_hive_formats()?;
         // PostgreSQL supports `WITH ( options )`, before `AS`
 
-        let _with_tag = if self.parse_keywords(&[Keyword::WITH, Keyword::TAG]) {
-            self.expect_token(&Token::LParen)?;
-            if !self.consume_token(&Token::RParen) {
-                let tags = self.parse_comma_separated(Parser::parse_sql_option)?;
-                self.expect_token(&Token::RParen)?;
-                Some(tags)
-            } else {
-                Some(vec![])
-            }
-        } else {
-            None
-        };
-
         // Parse CREATE TABLE clauses that can appear in any order after column definitions.
         // Different dialects (Snowflake, ClickHouse, BigQuery, Databricks, Redshift) allow
         // these clauses in varying orders, so we use a loop to flexibly accept them.
@@ -7553,6 +7540,7 @@ impl<'a> Parser<'a> {
         let mut strict = false;
         let mut inherits: Option<Vec<ObjectName>> = None;
         let mut table_policies: Vec<TablePolicy> = vec![];
+        let mut table_tags: Vec<Tag> = vec![];
 
         loop {
             // Table-level security/governance policy applications (Snowflake),
@@ -7575,7 +7563,8 @@ impl<'a> Parser<'a> {
                     if let Some(policy) = self.maybe_parse_table_policy(true)? {
                         table_policies.push(policy);
                         continue;
-                    } else if self.parse_optional_tag_clause() {
+                    } else if let Some(tags) = self.maybe_parse_tags()? {
+                        table_tags.extend(tags);
                         continue;
                     } else {
                         self.prev_token();
@@ -7737,8 +7726,9 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            // TAG (...) (Snowflake)
-            if self.parse_optional_tag_clause() {
+            // TAG (...) (Snowflake), bare (no WITH prefix)
+            if let Some(tags) = self.maybe_parse_tags()? {
+                table_tags.extend(tags);
                 continue;
             }
 
@@ -8096,6 +8086,7 @@ impl<'a> Parser<'a> {
             .location(location)
             .inherits(inherits)
             .table_policies(table_policies)
+            .table_tags(table_tags)
             .build())
     }
 
@@ -9153,6 +9144,29 @@ impl<'a> Parser<'a> {
         }))
     }
 
+    /// Parse a Snowflake `TAG ( <tag_name> = '<value>' [ , ... ] )` clause into
+    /// real AST nodes (tag name + string value). The optional `WITH` prefix is
+    /// consumed by the caller. Returns `None` (without consuming tokens) when
+    /// the next token isn't `TAG`.
+    /// <https://docs.snowflake.com/en/sql-reference/sql/create-table>
+    fn maybe_parse_tags(&mut self) -> Result<Option<Vec<Tag>>, ParserError> {
+        if !self.parse_keyword(Keyword::TAG) {
+            return Ok(None);
+        }
+        self.expect_token(&Token::LParen)?;
+        let tags = self.parse_comma_separated(|p| {
+            let name = p.parse_object_name(false)?;
+            p.expect_token(&Token::Eq)?;
+            let value = p.parse_literal_string()?;
+            Ok(Tag { name, value })
+        })?;
+        self.expect_token(&Token::RParen)?;
+        Ok(Some(tags))
+    }
+
+    /// Consume and discard a `TAG (...)` clause via balanced-paren skipping.
+    /// Used at the view / view-column sites that don't yet capture tags in the
+    /// AST; the CREATE TABLE sites use [`Self::maybe_parse_tags`] instead.
     fn parse_optional_tag_clause(&mut self) -> bool {
         if self.parse_keyword(Keyword::TAG) {
             if self.consume_token(&Token::LParen) {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1371,6 +1371,39 @@ fn bigquery() -> TestedDialects {
     }
 }
 
+#[test]
+fn parse_create_row_access_policy() {
+    // BigQuery row-level security.
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language
+    bigquery().verified_stmt(
+        "CREATE ROW ACCESS POLICY us_filter ON project.dataset.my_table GRANT TO ('user:abc@example.com') FILTER USING (region = 'US')",
+    );
+    bigquery().verified_stmt(
+        "CREATE OR REPLACE ROW ACCESS POLICY f ON ds.t GRANT TO ('domain:example.com', 'group:g@e.com') FILTER USING (region IN ('us-west1', 'us-west2'))",
+    );
+    // GRANT TO is optional.
+    bigquery().verified_stmt("CREATE ROW ACCESS POLICY f ON ds.t FILTER USING (a > 1)");
+
+    // FILTER USING may contain a subquery — its table ref must survive for lineage.
+    match bigquery().verified_stmt(
+        "CREATE OR REPLACE ROW ACCESS POLICY apac ON project.dataset.my_table GRANT TO ('domain:example.com') FILTER USING (region IN (SELECT region FROM lookup_table WHERE email = SESSION_USER()))",
+    ) {
+        Statement::CreateRowAccessPolicy {
+            name,
+            table_name,
+            grant_to,
+            filter_using,
+            ..
+        } => {
+            assert_eq!(name.to_string(), "apac");
+            assert_eq!(table_name.to_string(), "project.dataset.my_table");
+            assert_eq!(grant_to.len(), 1);
+            assert!(filter_using.to_string().contains("lookup_table"));
+        }
+        other => panic!("expected CreateRowAccessPolicy, got {other:?}"),
+    }
+}
+
 fn bigquery_unescaped() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(BigQueryDialect {})],

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -170,6 +170,7 @@ fn parse_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("y").empty_span(),
@@ -189,6 +190,7 @@ fn parse_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -759,6 +759,7 @@ fn parse_create_table_with_variant_default_expressions() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("b").empty_span(),
@@ -787,6 +788,7 @@ fn parse_create_table_with_variant_default_expressions() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("c").empty_span(),
@@ -801,6 +803,7 @@ fn parse_create_table_with_variant_default_expressions() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("d").empty_span(),
@@ -831,6 +834,7 @@ fn parse_create_table_with_variant_default_expressions() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("x").empty_span(),
@@ -846,6 +850,7 @@ fn parse_create_table_with_variant_default_expressions() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     }
                 ]
             )
@@ -865,6 +870,7 @@ fn column_def(name: Ident, data_type: DataType) -> ColumnDef {
         mask: None,
         column_location: None,
         column_policy: None,
+        tags: vec![],
     }
 }
 
@@ -962,6 +968,7 @@ fn parse_create_table_with_nullable() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     }
                 ]
             );
@@ -1008,6 +1015,7 @@ fn parse_create_table_with_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("k").empty_span(),
@@ -1036,6 +1044,7 @@ fn parse_create_table_with_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("l").empty_span(),
@@ -1064,6 +1073,7 @@ fn parse_create_table_with_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("m").empty_span(),
@@ -1078,6 +1088,7 @@ fn parse_create_table_with_nested_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );
@@ -1114,6 +1125,7 @@ fn parse_create_view_with_fields_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("f").empty_span(),
@@ -1131,6 +1143,7 @@ fn parse_create_view_with_fields_data_types() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2638,6 +2638,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lat").empty_span(),
@@ -2652,6 +2653,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lng").empty_span(),
@@ -2663,6 +2665,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("constrained").empty_span(),
@@ -2701,6 +2704,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("ref").empty_span(),
@@ -2724,6 +2728,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("ref2").empty_span(),
@@ -2744,6 +2749,7 @@ fn parse_create_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );
@@ -2883,6 +2889,7 @@ fn parse_create_table_with_constraint_characteristics() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lat").empty_span(),
@@ -2897,6 +2904,7 @@ fn parse_create_table_with_constraint_characteristics() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lng").empty_span(),
@@ -2908,6 +2916,7 @@ fn parse_create_table_with_constraint_characteristics() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );
@@ -3021,6 +3030,7 @@ fn parse_create_table_hive_array() {
                             mask: None,
                             column_location: None,
                             column_policy: None,
+                            tags: vec![],
                         },
                         ColumnDef {
                             name: Ident::new("val").empty_span(),
@@ -3032,6 +3042,7 @@ fn parse_create_table_hive_array() {
                             mask: None,
                             column_location: None,
                             column_policy: None,
+                            tags: vec![],
                         },
                     ],
                 )
@@ -3443,6 +3454,7 @@ fn parse_create_external_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lat").empty_span(),
@@ -3457,6 +3469,7 @@ fn parse_create_external_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("lng").empty_span(),
@@ -3468,6 +3481,7 @@ fn parse_create_external_table() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );
@@ -3529,6 +3543,7 @@ fn parse_create_or_replace_external_table() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 },]
             );
             assert!(constraints.is_empty());

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -154,6 +154,49 @@ fn test_underscore_column_name() {
 #[test]
 fn test_create_table_column_mask() {
     databricks().verified_stmt("CREATE TABLE persons (name STRING, ssn STRING MASK mask_ssn)");
+
+    // Column mask with USING COLUMNS (other column names and/or literals).
+    // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-column-mask
+    databricks().verified_stmt(
+        "CREATE TABLE persons (name STRING, address STRING MASK mask_pii USING COLUMNS (region), region STRING)",
+    );
+    match databricks().verified_stmt(
+        "CREATE TABLE t (address STRING MASK mask_addr USING COLUMNS (country, '_viewers'))",
+    ) {
+        Statement::CreateTable { columns, .. } => {
+            let mask = columns[0].mask.as_ref().expect("mask captured");
+            assert_eq!(mask.function.to_string(), "mask_addr");
+            assert_eq!(mask.using_columns.len(), 2);
+            assert_eq!(mask.using_columns[0].to_string(), "country");
+            assert_eq!(mask.using_columns[1].to_string(), "'_viewers'");
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_create_table_row_filter() {
+    // Databricks table-level row filter: `WITH ROW FILTER <func> ON (cols)`.
+    // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-row-filter
+    databricks().verified_stmt(
+        "CREATE TABLE employees (emp_name STRING, dept STRING) WITH ROW FILTER filter_emps ON (dept)",
+    );
+    match databricks()
+        .verified_stmt("CREATE TABLE sales (region STRING) WITH ROW FILTER us_filter ON (region)")
+    {
+        Statement::CreateTable { table_policies, .. } => {
+            assert_eq!(table_policies.len(), 1);
+            assert_eq!(table_policies[0].kind, TablePolicyKind::RowFilter);
+            assert_eq!(table_policies[0].policy_name.to_string(), "us_filter");
+            let cols: Vec<String> = table_policies[0]
+                .columns
+                .iter()
+                .map(|c| c.to_string())
+                .collect();
+            assert_eq!(cols, vec!["region".to_string()]);
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
 }
 
 #[test]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -332,6 +332,7 @@ fn parse_create_table_auto_increment() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 }],
                 columns
             );
@@ -387,6 +388,7 @@ fn parse_create_table_unique_key() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar").empty_span(),
@@ -401,6 +403,7 @@ fn parse_create_table_unique_key() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ],
                 columns
@@ -469,6 +472,7 @@ fn parse_create_table_set_enum() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("baz").empty_span(),
@@ -483,6 +487,7 @@ fn parse_create_table_set_enum() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     }
                 ],
                 columns
@@ -515,6 +520,7 @@ fn parse_create_table_engine_default_charset() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 },],
                 columns
             );
@@ -547,6 +553,7 @@ fn parse_create_table_collate() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 },],
                 columns
             );
@@ -584,6 +591,7 @@ fn parse_create_table_comment_character_set() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 },],
                 columns
             );
@@ -615,6 +623,7 @@ fn parse_quote_identifiers() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 }],
                 columns
             );
@@ -992,6 +1001,7 @@ fn parse_create_table_with_minimum_display_width() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_smallint").empty_span(),
@@ -1003,6 +1013,7 @@ fn parse_create_table_with_minimum_display_width() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_mediumint").empty_span(),
@@ -1014,6 +1025,7 @@ fn parse_create_table_with_minimum_display_width() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_int").empty_span(),
@@ -1025,6 +1037,7 @@ fn parse_create_table_with_minimum_display_width() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_bigint").empty_span(),
@@ -1036,6 +1049,7 @@ fn parse_create_table_with_minimum_display_width() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     }
                 ],
                 columns
@@ -1063,6 +1077,7 @@ fn parse_create_table_unsigned() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_smallint").empty_span(),
@@ -1074,6 +1089,7 @@ fn parse_create_table_unsigned() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_mediumint").empty_span(),
@@ -1085,6 +1101,7 @@ fn parse_create_table_unsigned() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_int").empty_span(),
@@ -1096,6 +1113,7 @@ fn parse_create_table_unsigned() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_bigint").empty_span(),
@@ -1107,6 +1125,7 @@ fn parse_create_table_unsigned() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ],
                 columns
@@ -1774,6 +1793,7 @@ fn parse_table_colum_option_on_update() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 }],
                 columns
             );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -342,6 +342,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("store_id").empty_span(),
@@ -356,6 +357,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("first_name").empty_span(),
@@ -375,6 +377,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("last_name").empty_span(),
@@ -394,6 +397,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("email").empty_span(),
@@ -410,6 +414,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("address_id").empty_span(),
@@ -424,6 +429,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("activebool").empty_span(),
@@ -444,6 +450,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("create_date").empty_span(),
@@ -466,6 +473,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("last_update").empty_span(),
@@ -486,6 +494,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("active").empty_span(),
@@ -500,6 +509,7 @@ fn parse_create_table_with_defaults() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );
@@ -677,6 +687,7 @@ fn parse_alter_table_add_columns() {
                             mask: None,
                             column_location: None,
                             column_policy: None,
+                            tags: vec![],
                         },
                     },
                     AlterTableOperation::AddColumn {
@@ -692,6 +703,7 @@ fn parse_alter_table_add_columns() {
                             mask: None,
                             column_location: None,
                             column_policy: None,
+                            tags: vec![],
                         },
                     },
                 ]
@@ -4148,6 +4160,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("int4_col").empty_span(),
@@ -4159,6 +4172,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("int2_col").empty_span(),
@@ -4170,6 +4184,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("float8_col").empty_span(),
@@ -4181,6 +4196,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("float4_col").empty_span(),
@@ -4192,6 +4208,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bool_col").empty_span(),
@@ -4203,6 +4220,7 @@ fn parse_create_table_with_alias() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ]
             );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2374,39 +2374,81 @@ fn parse_create_view_with_masking_policy() {
 
 #[test]
 fn parse_create_table_with_row_access_policy() {
-    // Snowflake CREATE TABLE trailing [WITH] ROW ACCESS POLICY <name> ON (cols)
-    // and [WITH] TAG (...). The WITH prefix is optional per
+    // Snowflake CREATE TABLE trailing [WITH] ROW ACCESS POLICY <name> ON (cols).
+    // The WITH prefix is optional per
     // https://docs.snowflake.com/en/sql-reference/sql/create-table
-    snowflake().one_statement_parses_to(
+    // The policy application (name + scoped columns) is preserved in the AST so
+    // column-level lineage can surface which policy guards the table.
+    snowflake().verified_stmt(
         "CREATE TABLE t1 (id VARCHAR, dept VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
-        "CREATE TABLE t1 (id VARCHAR, dept VARCHAR)",
     );
-    snowflake().one_statement_parses_to(
-        "CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY p1 ON (id)",
-        "CREATE TABLE t1 (id VARCHAR)",
-    );
+    snowflake().verified_stmt("CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY p1 ON (id)");
+    // TAG (...) is still consumed without an AST node — drop it on round-trip.
     snowflake().one_statement_parses_to(
         "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id) WITH TAG (k = 'v')",
-        "CREATE TABLE t1 (id VARCHAR)",
+        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
     );
     snowflake().one_statement_parses_to(
         "CREATE TABLE t1 (id VARCHAR) WITH TAG (k = 'v') WITH ROW ACCESS POLICY p1 ON (id)",
-        "CREATE TABLE t1 (id VARCHAR)",
+        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
     );
     // Snowflake's GET_DDL omits `ON (cols)` when the caller lacks privilege to
     // see the policy — it returns `WITH ROW ACCESS POLICY unknown_policy` only.
-    snowflake().one_statement_parses_to(
-        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY unknown_policy",
-        "CREATE TABLE t1 (id VARCHAR)",
-    );
-    snowflake().one_statement_parses_to(
-        "CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY unknown_policy",
-        "CREATE TABLE t1 (id VARCHAR)",
-    );
+    snowflake().verified_stmt("CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY unknown_policy");
+    snowflake().verified_stmt("CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY unknown_policy");
     snowflake().one_statement_parses_to(
         "CREATE VIEW v1 WITH ROW ACCESS POLICY unknown_policy AS SELECT * FROM t1",
         "CREATE VIEW v1 AS SELECT * FROM t1",
     );
+
+    // Assert the application is exposed in the AST (name + scoped columns).
+    match snowflake()
+        .verified_stmt("CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id, dept)")
+    {
+        Statement::CreateTable { table_policies, .. } => {
+            assert_eq!(table_policies.len(), 1);
+            let policy = &table_policies[0];
+            assert_eq!(policy.kind, TablePolicyKind::RowAccess);
+            assert!(policy.with);
+            assert_eq!(policy.policy_name.to_string(), "p1");
+            let cols: Vec<String> = policy.columns.iter().map(|c| c.to_string()).collect();
+            assert_eq!(cols, vec!["id".to_string(), "dept".to_string()]);
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_snowflake_create_table_aggregation_join_policy() {
+    // AGGREGATION POLICY uses ENTITY KEY (cols); JOIN POLICY uses ALLOWED JOIN
+    // KEYS (cols); both column lists are optional. WITH prefix is optional.
+    // https://docs.snowflake.com/en/sql-reference/sql/create-aggregation-policy
+    // https://docs.snowflake.com/en/sql-reference/sql/create-join-policy
+    snowflake().verified_stmt(
+        "CREATE TABLE t (id VARCHAR, grp VARCHAR) WITH AGGREGATION POLICY agg_pol ENTITY KEY (id)",
+    );
+    snowflake().verified_stmt("CREATE TABLE t (id VARCHAR) AGGREGATION POLICY agg_pol");
+    snowflake().verified_stmt(
+        "CREATE TABLE t (a VARCHAR, b VARCHAR) WITH JOIN POLICY jp ALLOWED JOIN KEYS (a, b)",
+    );
+    snowflake().verified_stmt("CREATE TABLE t (a VARCHAR) JOIN POLICY jp");
+
+    match snowflake().verified_stmt(
+        "CREATE TABLE t (a VARCHAR, b VARCHAR) WITH JOIN POLICY jp ALLOWED JOIN KEYS (a, b)",
+    ) {
+        Statement::CreateTable { table_policies, .. } => {
+            assert_eq!(table_policies.len(), 1);
+            assert_eq!(table_policies[0].kind, TablePolicyKind::Join);
+            assert_eq!(table_policies[0].policy_name.to_string(), "jp");
+            let cols: Vec<String> = table_policies[0]
+                .columns
+                .iter()
+                .map(|c| c.to_string())
+                .collect();
+            assert_eq!(cols, vec!["a".to_string(), "b".to_string()]);
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
 }
 
 #[test]
@@ -3178,11 +3220,26 @@ fn test_snowflake_create_dynamic_table_storage_lifecycle_policy() {
         WITH STORAGE LIFECYCLE POLICY expire_after_1w ON (order_date) \
         AS SELECT order_id, order_date FROM raw_orders";
     match snowflake().parse_sql_statements(sql).unwrap().remove(0) {
-        Statement::CreateTable { dynamic, query, .. } => {
+        Statement::CreateTable {
+            dynamic,
+            query,
+            table_policies,
+            ..
+        } => {
             assert!(dynamic);
             let q = query.expect("AS query should be preserved");
             assert!(q.to_string().contains("raw_orders"));
             assert!(q.to_string().contains("order_id"));
+            // The storage lifecycle policy application is captured.
+            assert_eq!(table_policies.len(), 1);
+            assert_eq!(table_policies[0].kind, TablePolicyKind::StorageLifecycle);
+            assert_eq!(table_policies[0].policy_name.to_string(), "expire_after_1w");
+            let cols: Vec<String> = table_policies[0]
+                .columns
+                .iter()
+                .map(|c| c.to_string())
+                .collect();
+            assert_eq!(cols, vec!["order_date".to_string()]);
         }
         other => panic!("expected CreateTable, got {other:?}"),
     }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2124,35 +2124,52 @@ fn test_column_with_masking() {
 
 #[test]
 fn test_table_with_tag() {
+    // Table-level TAG associations are now preserved in the AST (canonical
+    // form uses spaces around `=`). https://docs.snowflake.com/en/sql-reference/sql/create-table
+
     // Simple tag name
     snowflake().one_statement_parses_to(
         "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (UNKNOWN_TAG='#UNKNOWN_VALUE')",
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216))"
+        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (UNKNOWN_TAG = '#UNKNOWN_VALUE')"
     );
 
-    // Schema-qualified tag name
-    snowflake().one_statement_parses_to(
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (TAG_SCHEMA.DOMAIN_MAPPING='marketing')",
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216))"
+    // Schema-qualified and fully-qualified tag names round-trip.
+    snowflake().verified_stmt(
+        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (TAG_SCHEMA.DOMAIN_MAPPING = 'marketing')",
+    );
+    snowflake().verified_stmt(
+        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (PROD.TAG_SCHEMA.DOMAIN_MAPPING = 'marketing')",
     );
 
-    // Fully-qualified tag name (database.schema.tag)
-    snowflake().one_statement_parses_to(
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (PROD.TAG_SCHEMA.DOMAIN_MAPPING='marketing')",
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216))"
+    // Multiple tags with different qualification levels.
+    snowflake().verified_stmt(
+        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (SIMPLE_TAG = 'value1', SCHEMA.TAG_NAME = 'value2', DB.SCHEMA.TAG_NAME = 'value3')",
     );
 
-    // Multiple tags with different qualification levels
-    snowflake().one_statement_parses_to(
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (SIMPLE_TAG='value1', SCHEMA.TAG_NAME='value2', DB.SCHEMA.TAG_NAME='value3')",
-        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216))"
+    // Real-world example from the issue (anonymized).
+    snowflake().verified_stmt(
+        "CREATE OR REPLACE TABLE SCHEMA.DERIVED_TABLE (USER_ID VARCHAR(36), REPORTING_DATE TIMESTAMP_NTZ(9)) WITH TAG (STAGE.TAG_SCHEMA.DOMAIN_MAPPING = 'analytics')",
     );
 
-    // Real-world example from the issue (anonymized)
+    // Bare TAG (no WITH prefix) is accepted and normalized to `WITH TAG`.
     snowflake().one_statement_parses_to(
-        "CREATE OR REPLACE TABLE SCHEMA.DERIVED_TABLE (USER_ID VARCHAR(36), REPORTING_DATE TIMESTAMP_NTZ(9)) WITH TAG (STAGE.TAG_SCHEMA.DOMAIN_MAPPING='analytics')",
-        "CREATE OR REPLACE TABLE SCHEMA.DERIVED_TABLE (USER_ID VARCHAR(36), REPORTING_DATE TIMESTAMP_NTZ(9))"
+        "CREATE TABLE t (id VARCHAR) TAG (k = 'v')",
+        "CREATE TABLE t (id VARCHAR) WITH TAG (k = 'v')",
     );
+
+    // The associations are exposed in the AST (tag name + value).
+    match snowflake().verified_stmt(
+        "CREATE OR REPLACE TABLE TBL (ID VARCHAR(16777216)) WITH TAG (SCHEMA.DOMAIN = 'marketing', COST_CENTER = 'eng')",
+    ) {
+        Statement::CreateTable { table_tags, .. } => {
+            assert_eq!(table_tags.len(), 2);
+            assert_eq!(table_tags[0].name.to_string(), "SCHEMA.DOMAIN");
+            assert_eq!(table_tags[0].value, "marketing");
+            assert_eq!(table_tags[1].name.to_string(), "COST_CENTER");
+            assert_eq!(table_tags[1].value, "eng");
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
 }
 
 #[test]
@@ -2383,14 +2400,14 @@ fn parse_create_table_with_row_access_policy() {
         "CREATE TABLE t1 (id VARCHAR, dept VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
     );
     snowflake().verified_stmt("CREATE TABLE t1 (id VARCHAR) ROW ACCESS POLICY p1 ON (id)");
-    // TAG (...) is still consumed without an AST node — drop it on round-trip.
-    snowflake().one_statement_parses_to(
+    // ROW ACCESS POLICY and TAG together both round-trip (policies render
+    // before tags, so a tag-first input is reordered to the canonical form).
+    snowflake().verified_stmt(
         "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id) WITH TAG (k = 'v')",
-        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
     );
     snowflake().one_statement_parses_to(
         "CREATE TABLE t1 (id VARCHAR) WITH TAG (k = 'v') WITH ROW ACCESS POLICY p1 ON (id)",
-        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id)",
+        "CREATE TABLE t1 (id VARCHAR) WITH ROW ACCESS POLICY p1 ON (id) WITH TAG (k = 'v')",
     );
     // Snowflake's GET_DDL omits `ON (cols)` when the caller lacks privilege to
     // see the policy — it returns `WITH ROW ACCESS POLICY unknown_policy` only.

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2257,6 +2257,32 @@ fn test_snowflake_create_policy_definitions() {
 }
 
 #[test]
+fn test_snowflake_create_tag() {
+    // Snowflake tag definition.
+    // https://docs.snowflake.com/en/sql-reference/sql/create-tag
+    snowflake().verified_stmt("CREATE OR REPLACE TAG accounting");
+    snowflake().verified_stmt("CREATE TAG cost_center COMMENT = 'cost_center tag'");
+    snowflake()
+        .verified_stmt("CREATE TAG my_tag ALLOWED_VALUES 'blue', 'red' PROPAGATE = ON_DEPENDENCY");
+    snowflake().verified_stmt("CREATE TAG IF NOT EXISTS db.sch.t ALLOWED_VALUES 'a'");
+
+    match snowflake().verified_stmt("CREATE TAG cost_center ALLOWED_VALUES 'finance', 'eng'") {
+        Statement::CreateTag {
+            name,
+            allowed_values,
+            ..
+        } => {
+            assert_eq!(name.to_string(), "cost_center");
+            assert_eq!(
+                allowed_values,
+                vec!["finance".to_string(), "eng".to_string()]
+            );
+        }
+        other => panic!("expected CreateTag, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_describe_table() {
     snowflake().verified_stmt(r#"DESCRIBE TABLE "DW_PROD"."SCH"."TBL""#);
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2175,21 +2175,32 @@ fn test_table_with_tag() {
 #[test]
 fn test_column_with_tag() {
     // Column-level WITH TAG (...) — Snowflake docs allow `[ WITH ] TAG (...)` on columns,
-    // same shape as the table-level form.
-    snowflake().one_statement_parses_to(
-        "CREATE TABLE t (col NUMBER(18, 4) WITH TAG (a.b.c = 'True'))",
-        "CREATE TABLE t (col NUMBER(18, 4))",
-    );
+    // same shape as the table-level form. The associations are preserved in the AST.
+    snowflake().verified_stmt("CREATE TABLE t (col NUMBER(18, 4) WITH TAG (a.b.c = 'True'))");
     // Multiple columns, mixed with regular options.
-    snowflake().one_statement_parses_to(
+    snowflake().verified_stmt(
         "CREATE TABLE t (id INT, amt NUMBER(18, 4) WITH TAG (schema.tag = 'val'), name VARCHAR)",
-        "CREATE TABLE t (id INT, amt NUMBER(18, 4), name VARCHAR)",
     );
-    // Bare TAG (no WITH) still works (existing behavior).
+    // Bare TAG (no WITH) is normalized to the canonical `WITH TAG`.
     snowflake().one_statement_parses_to(
         "CREATE TABLE t (col NUMBER(18, 4) TAG (a.b = 'v'))",
-        "CREATE TABLE t (col NUMBER(18, 4))",
+        "CREATE TABLE t (col NUMBER(18, 4) WITH TAG (a.b = 'v'))",
     );
+
+    // The associations are exposed on the ColumnDef (tag name + value).
+    match snowflake().verified_stmt(
+        "CREATE TABLE t (amt NUMBER(18, 4) WITH TAG (schema.tag = 'val', cost = 'eng'))",
+    ) {
+        Statement::CreateTable { columns, .. } => {
+            assert_eq!(columns.len(), 1);
+            assert_eq!(columns[0].tags.len(), 2);
+            assert_eq!(columns[0].tags[0].name.to_string(), "schema.tag");
+            assert_eq!(columns[0].tags[0].value, "val");
+            assert_eq!(columns[0].tags[1].name.to_string(), "cost");
+            assert_eq!(columns[0].tags[1].value, "eng");
+        }
+        other => panic!("expected CreateTable, got {other:?}"),
+    }
 }
 
 #[test]
@@ -2716,10 +2727,11 @@ fn parse_column_comment_after_masking_policy() {
         "CREATE TABLE t1 (col1 VARCHAR COMMENT 'description' MASKING POLICY p1)",
     );
 
-    // Column COMMENT after TAG in CREATE TABLE
+    // Column COMMENT after TAG in CREATE TABLE — both preserved (COMMENT renders
+    // with the column options, the tag association after).
     snowflake().one_statement_parses_to(
         "CREATE TABLE t1 (col1 VARCHAR TAG (t1 = 'v1') COMMENT 'description')",
-        "CREATE TABLE t1 (col1 VARCHAR COMMENT 'description')",
+        "CREATE TABLE t1 (col1 VARCHAR COMMENT 'description' WITH TAG (t1 = 'v1'))",
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2204,6 +2204,59 @@ fn test_column_with_tag() {
 }
 
 #[test]
+fn test_snowflake_create_policy_definitions() {
+    // Snowflake policy definitions: signature + RETURNS + `-> body`.
+    // https://docs.snowflake.com/en/sql-reference/sql/create-masking-policy
+    // https://docs.snowflake.com/en/sql-reference/sql/create-row-access-policy
+    // https://docs.snowflake.com/en/sql-reference/sql/create-aggregation-policy
+    // https://docs.snowflake.com/en/sql-reference/sql/create-projection-policy
+    // https://docs.snowflake.com/en/sql-reference/sql/create-join-policy
+    snowflake().verified_stmt(
+        "CREATE MASKING POLICY email_mask AS (val VARCHAR) RETURNS VARCHAR -> CASE WHEN current_role() = 'ADMIN' THEN val ELSE '***' END",
+    );
+    snowflake().verified_stmt(
+        "CREATE OR REPLACE MASKING POLICY p AS (val STRING) RETURNS STRING -> val COMMENT = 'c' EXEMPT_OTHER_POLICIES = true",
+    );
+    snowflake().verified_stmt(
+        "CREATE AGGREGATION POLICY ap AS () RETURNS AGGREGATION_CONSTRAINT -> NO_AGGREGATION_CONSTRAINT()",
+    );
+    snowflake().verified_stmt(
+        "CREATE PROJECTION POLICY pp AS () RETURNS PROJECTION_CONSTRAINT -> PROJECTION_CONSTRAINT(ALLOW => true)",
+    );
+    snowflake().verified_stmt(
+        "CREATE JOIN POLICY jp AS () RETURNS JOIN_CONSTRAINT -> JOIN_CONSTRAINT(JOIN_REQUIRED => true)",
+    );
+    // Lowercase input normalizes types/keywords to canonical form.
+    snowflake().one_statement_parses_to(
+        "create masking policy m as (email varchar) returns varchar -> email",
+        "CREATE MASKING POLICY m AS (email VARCHAR) RETURNS VARCHAR -> email",
+    );
+
+    // The body Expr preserves table references for lineage (EXISTS subquery).
+    match snowflake().verified_stmt(
+        "CREATE ROW ACCESS POLICY rap AS (region VARCHAR) RETURNS BOOLEAN -> EXISTS (SELECT 1 FROM mgr_regions WHERE mgr = current_role())",
+    ) {
+        Statement::CreatePolicy {
+            kind,
+            name,
+            args,
+            returns,
+            body,
+            ..
+        } => {
+            assert_eq!(kind, PolicyKind::RowAccess);
+            assert_eq!(name.to_string(), "rap");
+            assert_eq!(args.len(), 1);
+            assert_eq!(args[0].name.to_string(), "region");
+            assert_eq!(returns.to_string(), "BOOLEAN");
+            // The referenced table is reachable in the body expression.
+            assert!(body.to_string().contains("mgr_regions"));
+        }
+        other => panic!("expected CreatePolicy, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_describe_table() {
     snowflake().verified_stmt(r#"DESCRIBE TABLE "DW_PROD"."SCH"."TBL""#);
 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -103,6 +103,7 @@ fn parse_create_table_auto_increment() {
                     mask: None,
                     column_location: None,
                     column_policy: None,
+                    tags: vec![],
                 }],
                 columns
             );
@@ -129,6 +130,7 @@ fn parse_create_sqlite_quote() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                     ColumnDef {
                         name: Ident::with_quote('[', "INDEX").empty_span(),
@@ -140,6 +142,7 @@ fn parse_create_sqlite_quote() {
                         mask: None,
                         column_location: None,
                         column_policy: None,
+                        tags: vec![],
                     },
                 ],
                 columns


### PR DESCRIPTION
Adds parser/AST support for capturing security & governance policies — which masking/access/governance policies are applied (and to which columns), plus the policy definitions themselves. Previously these clauses were parsed-and-discarded or skipped by the generic `CREATE` fallback, losing both the policy references and the lineage-bearing condition expressions.

## What's captured

**CREATE TABLE applications**
- Snowflake table-level `ROW ACCESS` / `AGGREGATION` / `JOIN` / `STORAGE LIFECYCLE` policies → new `TablePolicy { kind, with, policy_name, columns }`.
- Snowflake table- and column-level `TAG (k = 'v', ...)` → new `Tag { name, value }` (was discarded).
- Databricks `WITH ROW FILTER f ON (cols)` → `TablePolicyKind::RowFilter`; column `MASK f USING COLUMNS (...)` → `ColumnMask { function, using_columns }` (USING COLUMNS previously failed to parse).

**Policy definitions** (new `Statement` variants; bodies parsed as real `Expr` so subqueries/table refs stay visible)
- Snowflake `CREATE [OR REPLACE] {MASKING|ROW ACCESS|AGGREGATION|PROJECTION|JOIN} POLICY ... AS (sig) RETURNS type -> body` → `Statement::CreatePolicy`.
- Snowflake `CREATE TAG ... [ALLOWED_VALUES ...]` → `Statement::CreateTag`.
- BigQuery `CREATE [OR REPLACE] ROW ACCESS POLICY ... ON <table> [GRANT TO (...)] FILTER USING (<predicate>)` → `Statement::CreateRowAccessPolicy`.

Every new construct is justified against the vendor grammar (doc links are in each commit body). Round-trips via `Display`; the BigQuery form is dispatched after the Snowflake one (whose `AS` check reverts), so neither shadows the other.

## Validation
- Full unit suite green; new dialect tests assert the AST exposes policy/tag/table references.
- Corpus: 0 regressions, +5 files now parse structurally (3 Snowflake JOIN/AGGREGATION policy, 2 Databricks ROW FILTER/MASK); Snowflake/BigQuery definition files that previously only "parsed" via the skip-fallback now produce real AST.

## Follow-ups (later commits)
- ALTER applications (Snowflake `SET/UNSET POLICY|TAG`, Databricks `SET/DROP ROW FILTER|MASK`, T-SQL `ADD/DROP MASKED`).
- Redshift RLS/MASKING policy DDL; Postgres `CREATE POLICY` + RLS toggles; T-SQL `CREATE SECURITY POLICY`; BigQuery `DROP ROW ACCESS POLICY`.